### PR TITLE
Search additional path on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,53 +7,27 @@ addons:
     packages:
       - gcc-5
 
+os:
+  - linux
+  - osx
+
+rust: stable
+
+env:
+  - LLVM_VERSION=3.5 CLANG_VERSION=clang_3_5
+  - LLVM_VERSION=3.6 CLANG_VERSION=clang_3_6
+  - LLVM_VERSION=3.7 CLANG_VERSION=clang_3_7
+  - LLVM_VERSION=3.8 CLANG_VERSION=clang_3_8
+
 matrix:
   include:
-    - rust: stable
-      env: LLVM_VERSION=3.5.2 CLANG_VERSION=clang_3_5
-    - rust: stable
-      env: LLVM_VERSION=3.6.2 CLANG_VERSION=clang_3_6
-    - rust: stable
-      env: LLVM_VERSION=3.7.1 CLANG_VERSION=clang_3_7
-    - rust: stable
-      env: LLVM_VERSION=3.8.0 CLANG_VERSION=clang_3_8
-    - rust: beta
-      env: LLVM_VERSION=3.8.0 CLANG_VERSION=clang_3_8
-    - rust: nightly
-      env: LLVM_VERSION=3.8.0 CLANG_VERSION=clang_3_8
-    - os: osx
-      rust: stable
-      env: LLVM_VERSION=3.5 CLANG_VERSION=clang_3_5
-    - os: osx
-      rust: stable
-      env: LLVM_VERSION=3.6 CLANG_VERSION=clang_3_6
-    - os: osx
-      rust: stable
-      env: LLVM_VERSION=3.7 CLANG_VERSION=clang_3_7
-    - os: osx
-      rust: stable
+    - os: linux
+      rust: beta
+      env: LLVM_VERSION=3.8 CLANG_VERSION=clang_3_8
+    - os: linux
+      rust: nightly
       env: LLVM_VERSION=3.8 CLANG_VERSION=clang_3_8
 
-before_install:
-  -
-    set -e;
-    if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
-      brew update >/dev/null;
-      brew install llvm3${LLVM_VERSION#3.};
-      export LLVM_CONFIG_PATH=`brew --prefix llvm3${LLVM_VERSION#3.}`/lib/llvm-${LLVM_VERSION}/bin/llvm-config;
-    else
-      export LLVM=clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-14.04;
-      wget http://llvm.org/releases/${LLVM_VERSION}/${LLVM}.tar.xz ;
-      mkdir llvm;
-      tar -xf ${LLVM}.tar.xz -C llvm --strip-components=1;
-      export LLVM_CONFIG_PATH=`pwd`/llvm/bin/llvm-config;
-    fi
+before_install: . ./ci/before_install.sh
 
-script:
-  -
-    set -e;
-    RUST_BACKTRACE=1 cargo test --verbose --features $CLANG_VERSION;
-    if [ "${CLANG_VERSION}" != "clang_3_7" ] && [ "${CLANG_VERSION}" != "clang_3_8" ] ; then
-        cargo clean;
-        RUST_BACKTRACE=1 cargo test --verbose --features "$CLANG_VERSION static";
-    fi
+script: . ./ci/script.sh

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -6,15 +6,15 @@ function llvm_version_triple() {
     elif [ "$1" == "3.6" ]; then
         echo "3.6.2"
     elif [ "$1" == "3.7" ]; then
-        echo "3.7.1"
+        echo "3.7.0"
     elif [ "$1" == "3.8" ]; then
         echo "3.8.0"
     fi
 }
 
-function linux() {
+function llvm_download() {
     export LLVM_VERSION_TRIPLE=`llvm_version_triple ${LLVM_VERSION}`
-    export LLVM=clang+llvm-${LLVM_VERSION_TRIPLE}-x86_64-linux-gnu-ubuntu-14.04
+    export LLVM=clang+llvm-${LLVM_VERSION_TRIPLE}-x86_64-$1
 
     wget http://llvm.org/releases/${LLVM_VERSION_TRIPLE}/${LLVM}.tar.xz
     mkdir llvm
@@ -23,11 +23,8 @@ function linux() {
     export LLVM_CONFIG_PATH=`pwd`/llvm/bin/llvm-config
 }
 
-function osx() {
-    brew update >/dev/null
-    brew install llvm3${LLVM_VERSION#3.}
-
-    export LLVM_CONFIG_PATH=`brew --prefix llvm3${LLVM_VERSION#3.}`/lib/llvm-${LLVM_VERSION}/bin/llvm-config
-}
-
-if [ "${TRAVIS_OS_NAME}" == "osx" ]; then osx; else linux; fi
+if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+    llvm_download linux-gnu-ubuntu-14.04
+else
+    llvm_download apple-darwin
+fi

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -1,0 +1,33 @@
+set -e
+
+function llvm_version_triple() {
+    if [ "$1" == "3.5" ]; then
+        echo "3.5.2"
+    elif [ "$1" == "3.6" ]; then
+        echo "3.6.2"
+    elif [ "$1" == "3.7" ]; then
+        echo "3.7.1"
+    elif [ "$1" == "3.8" ]; then
+        echo "3.8.0"
+    fi
+}
+
+function linux() {
+    export LLVM_VERSION_TRIPLE=`llvm_version_triple ${LLVM_VERSION}`
+    export LLVM=clang+llvm-${LLVM_VERSION_TRIPLE}-x86_64-linux-gnu-ubuntu-14.04
+
+    wget http://llvm.org/releases/${LLVM_VERSION_TRIPLE}/${LLVM}.tar.xz
+    mkdir llvm
+    tar -xf ${LLVM}.tar.xz -C llvm --strip-components=1
+
+    export LLVM_CONFIG_PATH=`pwd`/llvm/bin/llvm-config
+}
+
+function osx() {
+    brew update >/dev/null
+    brew install llvm3${LLVM_VERSION#3.}
+
+    export LLVM_CONFIG_PATH=`brew --prefix llvm3${LLVM_VERSION#3.}`/lib/llvm-${LLVM_VERSION}/bin/llvm-config
+}
+
+if [ "${TRAVIS_OS_NAME}" == "osx" ]; then osx; else linux; fi

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,0 +1,8 @@
+set -e
+
+RUST_BACKTRACE=1 cargo test --verbose --features $CLANG_VERSION;
+
+if [ "${CLANG_VERSION}" \< "clang_3_7" ]; then
+    cargo clean
+    RUST_BACKTRACE=1 cargo test --verbose --features "$CLANG_VERSION static"
+fi

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,8 +1,8 @@
 set -e
 
-RUST_BACKTRACE=1 cargo test --verbose --features $CLANG_VERSION;
+RUST_BACKTRACE=1 cargo test --verbose --features $CLANG_VERSION -- --nocapture
 
 if [ "${CLANG_VERSION}" \< "clang_3_7" ]; then
     cargo clean
-    RUST_BACKTRACE=1 cargo test --verbose --features "$CLANG_VERSION static"
+    RUST_BACKTRACE=1 cargo test --verbose --features "$CLANG_VERSION static" -- --nocapture
 fi

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -28,5 +28,6 @@ fn test() {
 
 #[test]
 fn test_support() {
-    support::Clang::find(None).unwrap();
+    let clang = support::Clang::find(None).unwrap();
+    println!("{:?}", clang);
 }


### PR DESCRIPTION
On Windows, `libclang.dll` and `libclang.lib` are placed in different directories (`bin` and `lib` respectively), however you can use LIBCLANG_PATH to specify only one of the two directories (usually the `lib` directory).

This commit makes the build script additionally search the other directory so that people can always get the matching dll and lib files.