### PR TITLE
Implement Deref for opaque types.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -885,6 +885,7 @@ bitflags! {
 //================================================
 
 // Opaque ________________________________________
+//
 
 macro_rules! opaque {
     ($name:ident) => (
@@ -895,6 +896,14 @@ macro_rules! opaque {
         impl Default for $name {
             fn default() -> $name {
                 $name(ptr::null_mut())
+            }
+        }
+
+        impl std::ops::Deref for $name {
+            type Target = *mut c_void;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
             }
         }
     );

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -11,7 +11,7 @@ use libc::{c_char};
 fn test() {
     unsafe {
         let index = clang_createIndex(0, 0);
-        assert!(!index.0.is_null());
+        assert!(!index.is_null());
 
         let tu = clang_parseTranslationUnit(
             index,
@@ -22,7 +22,7 @@ fn test() {
             0,
             CXTranslationUnit_Flags::empty(),
         );
-        assert!(!tu.0.is_null());
+        assert!(!tu.is_null());
     }
 }
 


### PR DESCRIPTION
This enables the use of [Deref coercions](https://doc.rust-lang.org/book/deref-coercions.html), so you now can write code like this:

```rust
opaque_type.is_null()
````
Instead of:

```rust
opqaue_type.0.is_null()
```