### PR TITLE
Link against libc++ on freebsd and macos

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -231,10 +231,12 @@ fn main() {
         }
 
         // Specify required system libraries.
-        if cfg!(any(target_os="freebsd", target_os="linux")) {
+        if(cfg!(target_os="linux")) {
             println!("-l ffi -l ncursesw -l stdc++ -l z");
-        } else if cfg!(target_os="macos") {
-            println!("-l ffi -l ncurses -l stdc++ -l z");
+        } else if (cfg!(target_os="freebsd")) {
+            println!("-l ffi -l ncursesw -l c++ -l z");
+        } else if (cfg!(target_os="macos")) {
+            println!("-l ffi -l ncurses -l c++ -l z");
         } else {
             panic!("unsupported operating system for static linking");
         }


### PR DESCRIPTION
OSX and FreeBSD have both switched from using libstdc++ to using libc++
as their C++ standard library implementation a few years ago. This
change adjusts the link flags for both platforms accordingly.