### PR TITLE
Support linking clang from msys2's mingw environment

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -142,13 +142,13 @@ fn find(files: &[String], env: &str) -> Result<PathBuf, String> {
 /// Searches for a `libclang` shared library, returning the name of the shared library and the
 /// directory it can be found in if the search was successful.
 pub fn find_shared_library() -> Result<PathBuf, String> {
-    let files = if cfg!(target_os="windows") {
-        // The filename of the `libclang` shared library on Windows is `libclang.dll` instead of
-        // the expected `clang.dll`.
-        ["libclang.dll".into()]
-    } else {
-        [format!("{}clang{}", env::consts::DLL_PREFIX, env::consts::DLL_SUFFIX)]
-    };
+    let mut files = vec![];
+    if cfg!(target_os="windows") {
+        // The official LLVM build on Windows uses `libclang.dll` instead of `clang.dll`.
+        // However, unofficial builds like MINGW builds still use `clang.dll`.
+        files.push("libclang.dll".into());
+    }
+    files.push(format!("{}clang{}", env::consts::DLL_PREFIX, env::consts::DLL_SUFFIX));
     find(&files, "LIBCLANG_PATH")
 }
 

--- a/build.rs
+++ b/build.rs
@@ -245,8 +245,15 @@ fn main() {
         println!("cargo:rustc-link-search={}", directory.display());
         if cfg!(all(target_os="windows", target_env="msvc")) {
             // Find the `libclang` stub static library required for the MSVC toolchain.
-            let directory = find("libclang.lib", "LIBCLANG_PATH").unwrap();
-            println!("cargo:rustc-link-search={}", directory.display());
+            let libdir = if !directory.ends_with("bin") {
+                directory.clone()
+            } else {
+                directory.parent().unwrap().join("lib")
+            };
+            assert!(libdir.join("libclang.lib").exists(),
+                    "using dll file from {}, libclang.lib must be available in {}",
+                    directory.display(), libdir.display());
+            println!("cargo:rustc-link-search={}", libdir.display());
             println!("cargo:rustc-link-lib=dylib=libclang");
         } else {
             println!("cargo:rustc-link-lib=dylib=clang");

--- a/build.rs
+++ b/build.rs
@@ -74,6 +74,7 @@ const SEARCH_OSX: &'static [&'static str] = &[
 const SEARCH_WINDOWS: &'static [&'static str] = &[
     "C:\\LLVM\\lib",
     "C:\\Program Files*\\LLVM\\lib",
+    "C:\\msys*\\mingw*\\lib",
 ];
 
 /// Searches for a library, returning the directory it can be found in if the search was successful.

--- a/src/link.rs
+++ b/src/link.rs
@@ -104,7 +104,7 @@ macro_rules! link {
                 return Err("a `libclang` shared library has already been loaded".into());
             }
 
-            let file = try!(build::find_shared_library().map(|(d, f)| d.join(f)));
+            let file = try!(build::find_shared_library());
             let library = libloading::Library::new(&file).map_err(|_| {
                 format!("'{}' could not be opened", file.display())
             });


### PR DESCRIPTION
Clang in msys2's mingw uses some different settings. It provides `bin/clang.dll` instead of `bin/libclang.dll`, and `lib/libclang.dll.a` rather than `lib/libclang.lib`. I tested that, and it does work, at least with [servo/rust-bindgen](https://github.com/servo/rust-bindgen).

I also tested msys2's clang... but it doesn't seem to work, so it is not included here.