### PR TITLE
build: Also look for libclang.so.1 on linux.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -216,6 +216,11 @@ pub fn find_shared_library() -> Result<PathBuf, String> {
         files.push("libclang.dll".into());
     }
     files.push(format!("{}clang{}", env::consts::DLL_PREFIX, env::consts::DLL_SUFFIX));
+    if cfg!(target_os = "linux") {
+        // On some linux distros, they don't symlink to libclang.so, but
+        // libclang.so.1.
+        files.push("libclang.so.1".into());
+    }
     find(Library::Dynamic, &files, "LIBCLANG_PATH")
 }
 


### PR DESCRIPTION
See https://bugzil.la/1356150. This is the fix for it.

That being said, this feels like a one-off. Perhaps we could make it more generic and glob for `<prefix>clang.*.<suffix>.*` (or something a bit more accurate?)

Thanks!