### PR TITLE
Bump libloading version to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ static = []
 bitflags = "0.8.0"
 glob = "0.2.11"
 libc = "0.2.14"
-libloading = { version = "0.3.0", optional = true }
+libloading = { version = "0.4.0", optional = true }
 
 clippy = { version = "0.0.*", optional = true }
 


### PR DESCRIPTION
This update removes a (large) dependency incurred by libloading (namely, `target_build_utils` and it's dependency on serde_json).

It is related to this issue: https://github.com/servo/rust-bindgen/issues/499