### PR TITLE
Create dummy is_loaded function to emulate runtime API

### DIFF
--- a/src/link.rs
+++ b/src/link.rs
@@ -181,5 +181,10 @@ macro_rules! link {
 macro_rules! link {
     ($($(#[cfg($cfg:meta)])* pub fn $name:ident($($pname:ident: $pty:ty), *) $(-> $ret:ty)*;)+) => (
         extern { $($(#[cfg($cfg)])* pub fn $name($($pname: $pty), *) $(-> $ret)*;)+ }
+
+        $($(#[cfg($cfg)])*
+        pub mod $name {
+            pub fn is_loaded() -> bool { true }
+        })+
     )
 }


### PR DESCRIPTION
Switching `runtime` to `static` feature requires unnecessary changes in the code. 

I have `F::is_loaded()` expressions in many places, so it's hard to add `#[cfg]` to all of them, and I don't want to remove them permanently. So I've added dummy `is_loaded` functions to keep the code compatible even if it's statically linked.
