### PR TITLE
Static syntax fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 name = "clang-sys"
 authors = ["Kyle Mayes <kyle@mayeses.com>"]
 
-version = "0.20.0"
+version = "0.20.1"
 
 readme = "README.md"
 license = "Apache-2.0"

--- a/build.rs
+++ b/build.rs
@@ -318,7 +318,7 @@ fn link_static() {
 
     // Determine the shared mode used by LLVM.
     let mode = run_llvm_config(&["--shared-mode"]).map(|m| m.trim().to_owned());
-    let prefix = if mode.ok().map_or(false, |m| m == "static") { "static" } else { "" };
+    let prefix = if mode.ok().map_or(false, |m| m == "static") { "static=" } else { "" };
 
     // Specify required LLVM static libraries.
     println!("cargo:rustc-link-search=native={}", run_llvm_config(&["--libdir"]).unwrap().trim_right());


### PR DESCRIPTION
265db86c28d71ccf0edc8b382c527c6d41991073 introduced a syntax error, so clang-sys doesn't work with static builds at all now.