### PR TITLE
Produce better errors by including originals

### DIFF
--- a/src/link.rs
+++ b/src/link.rs
@@ -118,8 +118,8 @@ macro_rules! link {
             mod build;
 
             let file = try!(build::find_shared_library());
-            let library = libloading::Library::new(&file).map_err(|_| {
-                format!("the `libclang` shared library could not be opened: {}", file.display())
+            let library = libloading::Library::new(&file).map_err(|e| {
+                format!("the `libclang` shared library at {} could not be opened: {}", file.display(), e)
             });
             let mut library = SharedLibrary::new(try!(library));
             $(load::$name(&mut library);)+

--- a/src/support.rs
+++ b/src/support.rs
@@ -148,7 +148,7 @@ fn run(executable: &str, arguments: &[&str]) -> Result<(String, String), String>
         let stdout = String::from_utf8_lossy(&o.stdout).into_owned();
         let stderr = String::from_utf8_lossy(&o.stderr).into_owned();
         (stdout, stderr)
-    }).map_err(|_| format!("could not run executable: `{}`", executable))
+    }).map_err(|e| format!("could not run executable `{}`: {}", executable, e))
 }
 
 /// Runs `clang`, returning the `stdout` and `stderr` output.


### PR DESCRIPTION
In my case, this produced the error

Unable to find libclang: "the `libclang` shared library at "..." could
not be opened: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.20\' not
found (required by ...)"

which I needed in order to figure out what was wrong.