### PR TITLE
Don't use the std feature of libc.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ static = []
 [dependencies]
 
 glob = "0.2.11"
-libc = "0.2.39"
+libc = { version = "0.2.39", default-features = false }
 libloading = { version = "0.5.0", optional = true }
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 name = "clang-sys"
 authors = ["Kyle Mayes <kyle@mayeses.com>"]
 
-version = "0.26.2"
+version = "0.26.3"
 
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
It's not needed, and prevents some bindgen users from being able to run bindgen
at build time in no_std crates, see rust-lang-nursery/rust-bindgen#1439.