### PR TITLE
link: Keep the path of the shared library around when loading the library at runtime.

### DIFF
--- a/src/link.rs
+++ b/src/link.rs
@@ -41,6 +41,7 @@ macro_rules! link {
     ($($(#[cfg($cfg:meta)])* pub fn $name:ident($($pname:ident: $pty:ty), *) $(-> $ret:ty)*;)+) => (
         use std::cell::{RefCell};
         use std::sync::{Arc};
+        use std::path::{Path, PathBuf};
 
         /// The set of functions loaded dynamically.
         #[derive(Debug, Default)]
@@ -52,14 +53,19 @@ macro_rules! link {
         #[derive(Debug)]
         pub struct SharedLibrary {
             library: libloading::Library,
+            path: PathBuf,
             pub functions: Functions,
         }
 
         impl SharedLibrary {
             //- Constructors -----------------------------
 
-            fn new(library: libloading::Library) -> SharedLibrary {
-                SharedLibrary { library: library, functions: Functions::default() }
+            fn new(library: libloading::Library, path: PathBuf) -> SharedLibrary {
+                SharedLibrary { library, path, functions: Functions::default() }
+            }
+
+            pub fn path(&self) -> &Path {
+                &self.path
             }
         }
 
@@ -130,7 +136,7 @@ macro_rules! link {
                 )
             });
 
-            let mut library = SharedLibrary::new(try!(library));
+            let mut library = SharedLibrary::new(try!(library), path);
             $(load::$name(&mut library);)+
             Ok(library)
         }


### PR DESCRIPTION
It's useful to debug stuff, and include it in some debugging logs.