### PR TITLE
Add missing linkage for clang_CompileCommand_getNumMappedSources

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1653,6 +1653,7 @@ link! {
     #[cfg(feature="gte_clang_3_8")]
     pub fn clang_CompileCommand_getMappedSourcePath(command: CXCompileCommand, index: c_uint) -> CXString;
     pub fn clang_CompileCommand_getNumArgs(command: CXCompileCommand) -> c_uint;
+    pub fn clang_CompileCommand_getNumMappedSources(command: CXCompileCommand) -> c_uint;
     pub fn clang_CompileCommands_dispose(command: CXCompileCommands);
     pub fn clang_CompileCommands_getCommand(command: CXCompileCommands, index: c_uint) -> CXCompileCommand;
     pub fn clang_CompileCommands_getSize(command: CXCompileCommands) -> c_uint;


### PR DESCRIPTION
By testing out the compilation database features of libclang, I notices that the binding for [`clang_CompileCommand_getNumMappedSources`](https://clang.llvm.org/doxygen/group__COMPILATIONDB.html#ga28b373614893bffe6ae3f7c53ef8a851) was missing. 
However, other functions regarding mapped sources were correctly defined (`clang_CompileCommand_getMappedSourcePath`, `clang_CompileCommand_getMappedSourceContent`).