### PR TITLE
libclang 9.0 bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 name = "clang-sys"
 authors = ["Kyle Mayes <kyle@mayeses.com>"]
 
-version = "0.28.1"
+version = "0.29.0"
 
 readme = "README.md"
 license = "Apache-2.0"
@@ -28,6 +28,8 @@ clang_5_0 = ["gte_clang_3_6", "gte_clang_3_7", "gte_clang_3_8", "gte_clang_3_9",
 clang_6_0 = ["gte_clang_3_6", "gte_clang_3_7", "gte_clang_3_8", "gte_clang_3_9", "gte_clang_4_0", "gte_clang_5_0", "gte_clang_6_0"]
 clang_7_0 = ["gte_clang_3_6", "gte_clang_3_7", "gte_clang_3_8", "gte_clang_3_9", "gte_clang_4_0", "gte_clang_5_0", "gte_clang_6_0", "gte_clang_7_0"]
 clang_8_0 = ["gte_clang_3_6", "gte_clang_3_7", "gte_clang_3_8", "gte_clang_3_9", "gte_clang_4_0", "gte_clang_5_0", "gte_clang_6_0", "gte_clang_7_0", "gte_clang_8_0"]
+clang_9_0 = ["gte_clang_3_6", "gte_clang_3_7", "gte_clang_3_8", "gte_clang_3_9", "gte_clang_4_0", "gte_clang_5_0", "gte_clang_6_0", "gte_clang_7_0", "gte_clang_8_0", "gte_clang_9_0"]
+
 
 gte_clang_3_6 = []
 gte_clang_3_7 = []
@@ -38,6 +40,7 @@ gte_clang_5_0 = []
 gte_clang_6_0 = []
 gte_clang_7_0 = []
 gte_clang_8_0 = []
+gte_clang_9_0 = []
 
 runtime = ["libloading"]
 static = []
@@ -45,8 +48,8 @@ static = []
 [dependencies]
 
 glob = "0.3"
-libc = { version = "0.2.39", default-features = false }
-libloading = { version = "0.5.0", optional = true }
+libc = { version = "0.2.66", default-features = false }
+libloading = { version = "0.5.2", optional = true }
 
 [build-dependencies]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ clang_7_0 = ["gte_clang_3_6", "gte_clang_3_7", "gte_clang_3_8", "gte_clang_3_9",
 clang_8_0 = ["gte_clang_3_6", "gte_clang_3_7", "gte_clang_3_8", "gte_clang_3_9", "gte_clang_4_0", "gte_clang_5_0", "gte_clang_6_0", "gte_clang_7_0", "gte_clang_8_0"]
 clang_9_0 = ["gte_clang_3_6", "gte_clang_3_7", "gte_clang_3_8", "gte_clang_3_9", "gte_clang_4_0", "gte_clang_5_0", "gte_clang_6_0", "gte_clang_7_0", "gte_clang_8_0", "gte_clang_9_0"]
 
-
 gte_clang_3_6 = []
 gte_clang_3_7 = []
 gte_clang_3_8 = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,9 +25,11 @@
 //! * 5.0 - [Documentation](https://kylemayes.github.io/clang-sys/5_0/clang_sys)
 //! * 6.0 - [Documentation](https://kylemayes.github.io/clang-sys/6_0/clang_sys)
 //! * 7.0 - [Documentation](https://kylemayes.github.io/clang-sys/7_0/clang_sys)
+//! * 8.0 - [Documentation](https://kylemayes.github.io/clang-sys/8_0/clang_sys)
+//! * 9.0 - [Documentation](https://kylemayes.github.io/clang-sys/9_0/clang_sys)
 
 #![allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
-#![cfg_attr(feature = "cargo-clippy", allow(unreadable_literal))]
+#![cfg_attr(feature = "cargo-clippy", allow(clippy::unreadable_literal))]
 
 extern crate glob;
 extern crate libc;
@@ -128,6 +130,8 @@ cenum! {
         const CXCallingConv_PreserveMost = 14,
         /// Only produced by `libclang` 3.9 and later.
         const CXCallingConv_PreserveAll = 15,
+        /// Only produced by `libclang` 8.0 and later.
+        const CXCallingConv_AArch64VectorCall = 16,
         const CXCallingConv_Invalid = 100,
         const CXCallingConv_Unexposed = 200,
     }
@@ -431,6 +435,8 @@ cenum! {
         const CXCursor_OMPTargetTeamsDistributeParallelForSimdDirective = 278,
         /// Only producer by `libclang` 4.0 and later.
         const CXCursor_OMPTargetTeamsDistributeSimdDirective = 279,
+        /// Only produced by 'libclang' 9.0 and later.
+        const CXCursor_BuiltinBitCastExpr = 280,
         const CXCursor_TranslationUnit = 300,
         const CXCursor_UnexposedAttr = 400,
         const CXCursor_IBActionAttr = 401,
@@ -492,6 +498,14 @@ cenum! {
         const CXCursor_ObjCBoxable = 436,
         /// Only produced by `libclang` 8.0 and later.
         const CXCursor_FlagEnum = 437,
+        /// Only produced by `libclang` 9.0 and later.
+        const CXCursor_ConvergentAttr  = 438,
+        /// Only produced by `libclang` 9.0 and later.
+        const CXCursor_WarnUnusedAttr = 439,
+        /// Only produced by `libclang` 9.0 and later.
+        const CXCursor_WarnUnusedResultAttr = 440,
+        /// Only produced by `libclang` 9.0 and later.
+        const CXCursor_AlignedAttr = 441,
         const CXCursor_PreprocessingDirective = 500,
         const CXCursor_MacroDefinition = 501,
         /// Duplicate of `CXCursor_MacroInstantiation`.
@@ -521,6 +535,8 @@ cenum! {
         const CXCursor_ExceptionSpecificationKind_Unevaluated = 6,
         const CXCursor_ExceptionSpecificationKind_Uninstantiated = 7,
         const CXCursor_ExceptionSpecificationKind_Unparsed = 8,
+        #[cfg(feature="gte_clang_9_0")]
+        const CXCursor_ExceptionSpecificationKind_NoThrow = 9,
     }
 }
 
@@ -955,6 +971,8 @@ cenum! {
         const CXType_OCLIntelSubgroupAVCImeSingleRefStreamin = 174,
         /// Only produced by `libclang` 8.0 and later.
         const CXType_OCLIntelSubgroupAVCImeDualRefStreamin = 175,
+        /// Only produced by `libclang` 9.0 and later.
+        const CXType_ExtVector = 176,
     }
 }
 
@@ -965,6 +983,8 @@ cenum! {
         const CXTypeLayoutError_Dependent = -3,
         const CXTypeLayoutError_NotConstantSize = -4,
         const CXTypeLayoutError_InvalidFieldName = -5,
+        /// Only produced by `libclang` 9.0 and later.
+        const CXTypeLayoutError_Undeduced = -6,
     }
 }
 
@@ -1190,6 +1210,8 @@ cenum! {
         const CXTranslationUnit_IncludeAttributedTypes = 4096;
         #[cfg(feature="gte_clang_8_0")]
         const CXTranslationUnit_VisitImplicitAttributes = 8192;
+        #[cfg(feature="gte_clang_9_0")]
+        const CXTranslationUnit_IgnoreNonErrorsFromIncludedFiles = 16384;
     }
 }
 
@@ -1680,6 +1702,10 @@ link! {
     pub fn clang_Cursor_getObjCSelectorIndex(cursor: CXCursor) -> c_int;
     #[cfg(feature="gte_clang_3_7")]
     pub fn clang_Cursor_getOffsetOfField(cursor: CXCursor) -> c_longlong;
+    #[cfg(feature="gte_clang_9_0")]
+    pub fn clang_Cursor_isAnonymousRecordDecl(cursor: CXCursor) -> c_uint;
+    #[cfg(feature="gte_clang_9_0")]
+    pub fn clang_Cursor_isInlineNamespace(cursor: CXCursor) -> c_uint;
     pub fn clang_Cursor_getRawCommentText(cursor: CXCursor) -> CXString;
     pub fn clang_Cursor_getReceiverType(cursor: CXCursor) -> CXType;
     pub fn clang_Cursor_getSpellingNameRange(cursor: CXCursor, index: c_uint, reserved: c_uint) -> CXSourceRange;


### PR DESCRIPTION
- Added the things I could find that had changed in libclang 9.0 
- Added CXCallingConv_AArch64VectorCall ( available since libclang 8.0 ) 
- Bumped libc and libloading versions
- Changed unreadable_literal  ->  clippy::unreadable_literal 