### PR TITLE
Don't enforce unnecessarily new versions of libc / libloading.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ static = []
 [dependencies]
 
 glob = "0.3"
-libc = { version = "0.2.66", default-features = false }
-libloading = { version = "0.5.2", optional = true }
+libc = { version = "0.2.39", default-features = false }
+libloading = { version = "0.5", optional = true }
 
 [build-dependencies]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 name = "clang-sys"
 authors = ["Kyle Mayes <kyle@mayeses.com>"]
 
-version = "0.29.1"
+version = "0.29.2"
 
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
This causes unnecessary complications, and it's not required for clang-sys to
work.

This was regressed in #101, and it's unnecessarily preventing us from updating
bindgen in Firefox.