### PR TITLE
Update libloading to version 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ static = []
 
 glob = "0.3"
 libc = { version = "0.2.39", default-features = false }
-libloading = { version = "0.5", optional = true }
+libloading = { version = "0.6", optional = true }
 
 [build-dependencies]
 


### PR DESCRIPTION
Resolves #111

Update seems to be retro compatible, I've checked:
- `cargo check --features="runtime"`
- `cargo test --features="runtime"`
