### PR TITLE
Dynamic lookup fixes

### DIFF
--- a/build/dynamic.rs
+++ b/build/dynamic.rs
@@ -181,6 +181,7 @@ fn search_libclang_directories(runtime: bool) -> Result<Vec<(PathBuf, String, Ve
 pub fn find(runtime: bool) -> Result<(PathBuf, String), String> {
     search_libclang_directories(runtime)?
         .iter()
+        .rev() // `max_by_key` picks the last one but we want the first.
         .max_by_key(|f| &f.2)
         .cloned()
         .map(|(path, filename, _)| (path, filename))

--- a/src/support.rs
+++ b/src/support.rs
@@ -84,11 +84,11 @@ impl Clang {
             paths.push(path.into());
         }
         if let Ok(path) = run_llvm_config(&["--bindir"]) {
-            paths.push(path.into());
+            paths.push(path.lines().next().unwrap().into());
         }
         if cfg!(target_os = "macos") {
             if let Ok((path, _)) = run("xcodebuild", &["-find", "clang"]) {
-                paths.push(path.into());
+                paths.push(path.lines().next().unwrap().into());
             }
         }
         paths.extend(env::split_paths(&env::var("PATH").unwrap()));


### PR DESCRIPTION
Runtime lookup using `LLVM_CONFIG_PATH` was not giving me the results I expected, but it does with these patches.

1. `llvm-config --bindir` and `xcodebuild -find clang` were not working because the trailing newline was being interpreted as part of the path
2. Between multiple installations with the same version, the system one was being selected instead of the local one I wanted, because it was _lower_ in the priority list and `max_by_key` inverts the order