### PR TITLE
Upgrade libloading dep to 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ static = []
 
 glob = "0.3"
 libc = { version = "0.2.39", default-features = false }
-libloading = { version = "0.6", optional = true }
+libloading = { version = "0.7", optional = true }
 
 [build-dependencies]
 

--- a/src/link.rs
+++ b/src/link.rs
@@ -195,17 +195,19 @@ macro_rules! link {
             let (directory, filename) = build::dynamic::find(true)?;
             let path = directory.join(filename);
 
-            let library = libloading::Library::new(&path).map_err(|e| {
-                format!(
-                    "the `libclang` shared library at {} could not be opened: {}",
-                    path.display(),
-                    e,
-                )
-            });
+            unsafe {
+                let library = libloading::Library::new(&path).map_err(|e| {
+                    format!(
+                        "the `libclang` shared library at {} could not be opened: {}",
+                        path.display(),
+                        e,
+                    )
+                });
 
-            let mut library = SharedLibrary::new(library?, path);
-            $(load::$name(&mut library);)+
-            Ok(library)
+                let mut library = SharedLibrary::new(library?, path);
+                $(load::$name(&mut library);)+
+                Ok(library)
+            }
         }
 
         /// Loads a `libclang` shared library for use in the current thread.


### PR DESCRIPTION
Libloading 0.7 requires an unsafe wrapper around Library::new().