### PR TITLE
Add Scoop support on windows

### DIFF
--- a/build/common.rs
+++ b/build/common.rs
@@ -49,6 +49,9 @@ const DIRECTORIES_WINDOWS: &[&str] = &[
     // LLVM + Clang can be installed as a component of Visual Studio.
     // https://github.com/KyleMayes/clang-sys/issues/121
     "C:\\Program Files*\\Microsoft Visual Studio\\*\\BuildTools\\VC\\Tools\\Llvm\\**\\bin",
+    // Scoop user installation https://scoop.sh/.
+    // Chocolatey, WinGet and other installers use to the system wide dir listed above
+    "C:\\Users\\*\\scoop\\apps\\llvm\\current\\bin",
 ];
 
 thread_local! {


### PR DESCRIPTION
[Scoop](https://github.com/lukesampson/scoop) is a popular command-line installer used on Windows with a behavior similar to Homebrew on MacOS. It seems reasonable to have support for the default user installation path.
Instead of fetching the current user and restrict the search to it, I rely on having the glob failing on others users for lack of necessary permissions. If the maintainers feel more comfortable with a specific code path to handle this use case, I can do the extra changes. I also chose the current instead of globbing all the available versions.