### PR TITLE
check clang bin is not a directory BEFORE trying to execute it

### DIFF
--- a/src/support.rs
+++ b/src/support.rs
@@ -58,7 +58,10 @@ impl Clang {
     /// `x86_64-unknown-linux-gnu-clang` for the above example).
     pub fn find(path: Option<&Path>, args: &[String]) -> Option<Clang> {
         if let Ok(path) = env::var("CLANG_PATH") {
-            return Some(Clang::new(path, args));
+            let p = Path::new(&path);
+            if p.is_file() && is_executable(&p).unwrap_or(false) {
+                return Some(Clang::new(p, args));
+            }
         }
 
         // Determine the cross-compilation target, if any.


### PR DESCRIPTION
If $CLANG_PATH is set, but doesn't point to a clang binary (but say, the
source code directory of clang) bindgen will fail with cryptic errors
pointing back to clang-sys:

    thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value:
    "could not run executable `/llvm-project/clang`: Permission denied (os
    error 13)"',
     ~/.cargo/registry/src/github.com-1ecc6299db9ec823/clang-sys-1.0.3/src/support.rs:165:58

Check this env var points to an executable file or ignore it.

Fixes #138