### PR TITLE
Simplify loading API.

### DIFF
--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -28,10 +28,10 @@ fn parse() {
 #[cfg(feature = "runtime")]
 #[test]
 fn test() {
-    load().unwrap();
-    let library = get_library().unwrap();
+    let library = load().unwrap();
     println!("{:?} ({:?})", library.version(), library.path());
     parse();
+    drop(library);
     unload().unwrap();
 }
 


### PR DESCRIPTION
As I understand from https://github.com/KyleMayes/clang-rs/issues/26, the library should only be loaded once per thread. 

This changes the `load` method so it returns an `Rc<SharedLibrary>`, since you cannot share the library across threads anyways.

This also removes the `get/set_library` function, which previously claimed they allow sharing the library across threads, which should not be possible.

The `unload` method returns an error if the current thread still references the library.