### PR TITLE
Various updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         clang: [["14.0", "clang_14_0"]]
-        rust: ["1.40.0"]
+        rust: ["1.51.0"]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/.github/workflows/ssh.yml
+++ b/.github/workflows/ssh.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         clang: [["13.0", "clang_13_0"]]
-        rust: ["1.40.0"]
+        rust: ["1.51.0"]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Changed
 - Bumped minimum supported Rust version (MSRV) to 1.51.0
+- Changed Windows search directory preferences (`libclang` instances from
+Visual Studio installs are now the lowest priority rather than the second
+highest)
 
 ### Added
 - Added additional support for `clang` 16.0.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.4.1] - UNRELEASED
+
+- Added additional support for `clang` 16.0.x
+
 ## [1.4.0] - 2022-09-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [1.4.1] - UNRELEASED
 
+### Changed
+- Bumped minimum supported Rust version (MSRV) to 1.51.0
+
+### Added
 - Added additional support for `clang` 16.0.x
 
 ## [1.4.0] - 2022-09-22

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ glob = "0.3"
 [dev-dependencies]
 
 glob = "0.3"
+serial_test = "1"
 tempdir = "0.3"
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,11 @@ libloading = { version = "0.7", optional = true }
 
 glob = "0.3"
 
+[dev-dependencies]
+
+glob = "0.3"
+tempdir = "0.3"
+
 [package.metadata.docs.rs]
 
 features = ["clang_16_0", "runtime"]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Crate](https://img.shields.io/crates/v/clang-sys.svg)](https://crates.io/crates/clang-sys)
 [![Documentation](https://docs.rs/clang-sys/badge.svg)](https://docs.rs/clang-sys)
 [![CI](https://img.shields.io/github/actions/workflow/status/KyleMayes/clang-sys/ci.yml?branch=master)](https://github.com/KyleMayes/clang-sys/actions?query=workflow%3ACI)
-![MSRV](https://img.shields.io/badge/MSRV-1.40.0-blue)
+![MSRV](https://img.shields.io/badge/MSRV-1.51.0-blue)
 
 Rust bindings for `libclang`.
 

--- a/build.rs
+++ b/build.rs
@@ -19,6 +19,10 @@ extern crate glob;
 
 use std::path::Path;
 
+#[macro_use]
+#[path = "build/macros.rs"]
+pub mod macros;
+
 #[path = "build/common.rs"]
 pub mod common;
 #[path = "build/dynamic.rs"]
@@ -54,6 +58,7 @@ fn main() {
     }
 
     let out = env::var("OUT_DIR").unwrap();
+    copy("build/macros.rs", &Path::new(&out).join("macros.rs"));
     copy("build/common.rs", &Path::new(&out).join("common.rs"));
     copy("build/dynamic.rs", &Path::new(&out).join("dynamic.rs"));
 }

--- a/build/common.rs
+++ b/build/common.rs
@@ -175,11 +175,11 @@ const DIRECTORIES_WINDOWS: &[&str] = &[
     "C:\\MSYS*\\MinGW*\\lib",
     // LLVM + Clang can be installed as a component of Visual Studio.
     // https://github.com/KyleMayes/clang-sys/issues/121
-    "C:\\Program Files*\\Microsoft Visual Studio\\*\\BuildTools\\VC\\Tools\\Llvm\\**\\bin",
+    "C:\\Program Files*\\Microsoft Visual Studio\\*\\BuildTools\\VC\\Tools\\Llvm\\**\\lib",
     // LLVM + Clang can be installed using Scoop (https://scoop.sh).
     // Other Windows package managers install LLVM + Clang to previously listed
     // system-wide directories.
-    "C:\\Users\\*\\scoop\\apps\\llvm\\current\\bin",
+    "C:\\Users\\*\\scoop\\apps\\llvm\\current\\lib",
 ];
 
 /// `libclang` directory patterns for illumos

--- a/build/common.rs
+++ b/build/common.rs
@@ -181,12 +181,12 @@ const DIRECTORIES_WINDOWS: &[&str] = &[
     // Other Windows package managers install LLVM + Clang to previously listed
     // system-wide directories.
     "C:\\Users\\*\\scoop\\apps\\llvm\\current\\lib",
-    // LLVM + Clang can be installed as a component of Visual Studio.
-    // https://github.com/KyleMayes/clang-sys/issues/121
-    "C:\\Program Files*\\Microsoft Visual Studio\\*\\BuildTools\\VC\\Tools\\Llvm\\**\\lib",
     "C:\\MSYS*\\MinGW*\\lib",
     "C:\\Program Files*\\LLVM\\lib",
     "C:\\LLVM\\lib",
+    // LLVM + Clang can be installed as a component of Visual Studio.
+    // https://github.com/KyleMayes/clang-sys/issues/121
+    "C:\\Program Files*\\Microsoft Visual Studio\\*\\BuildTools\\VC\\Tools\\Llvm\\**\\lib",
 ];
 
 /// `libclang` directory patterns for illumos

--- a/build/common.rs
+++ b/build/common.rs
@@ -138,54 +138,61 @@ pub fn run_xcode_select(arguments: &[&str]) -> Option<String> {
 //================================================
 // Search Directories
 //================================================
+// These search directories are listed in order of
+// preference, so if multiple `libclang` instances
+// are found when searching matching directories,
+// the `libclang` instances from earlier
+// directories will be preferred (though version
+// takes precedence over location).
+//================================================
 
 /// `libclang` directory patterns for Haiku.
 const DIRECTORIES_HAIKU: &[&str] = &[
-    "/boot/system/lib",
-    "/boot/system/develop/lib",
-    "/boot/system/non-packaged/lib",
-    "/boot/system/non-packaged/develop/lib",
-    "/boot/home/config/non-packaged/lib",
     "/boot/home/config/non-packaged/develop/lib",
+    "/boot/home/config/non-packaged/lib",
+    "/boot/system/non-packaged/develop/lib",
+    "/boot/system/non-packaged/lib",
+    "/boot/system/develop/lib",
+    "/boot/system/lib",
 ];
 
 /// `libclang` directory patterns for Linux (and FreeBSD).
 const DIRECTORIES_LINUX: &[&str] = &[
-    "/usr/lib*",
-    "/usr/lib*/*",
-    "/usr/lib*/*/*",
-    "/usr/local/lib*",
-    "/usr/local/lib*/*",
-    "/usr/local/lib*/*/*",
     "/usr/local/llvm*/lib*",
+    "/usr/local/lib*/*/*",
+    "/usr/local/lib*/*",
+    "/usr/local/lib*",
+    "/usr/lib*/*/*",
+    "/usr/lib*/*",
+    "/usr/lib*",
 ];
 
 /// `libclang` directory patterns for macOS.
 const DIRECTORIES_MACOS: &[&str] = &[
-    "/usr/local/opt/llvm*/lib",
-    "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib",
-    "/Library/Developer/CommandLineTools/usr/lib",
     "/usr/local/opt/llvm*/lib/llvm*/lib",
+    "/Library/Developer/CommandLineTools/usr/lib",
+    "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib",
+    "/usr/local/opt/llvm*/lib",
 ];
 
 /// `libclang` directory patterns for Windows.
 const DIRECTORIES_WINDOWS: &[&str] = &[
-    "C:\\LLVM\\lib",
-    "C:\\Program Files*\\LLVM\\lib",
-    "C:\\MSYS*\\MinGW*\\lib",
-    // LLVM + Clang can be installed as a component of Visual Studio.
-    // https://github.com/KyleMayes/clang-sys/issues/121
-    "C:\\Program Files*\\Microsoft Visual Studio\\*\\BuildTools\\VC\\Tools\\Llvm\\**\\lib",
     // LLVM + Clang can be installed using Scoop (https://scoop.sh).
     // Other Windows package managers install LLVM + Clang to previously listed
     // system-wide directories.
     "C:\\Users\\*\\scoop\\apps\\llvm\\current\\lib",
+    // LLVM + Clang can be installed as a component of Visual Studio.
+    // https://github.com/KyleMayes/clang-sys/issues/121
+    "C:\\Program Files*\\Microsoft Visual Studio\\*\\BuildTools\\VC\\Tools\\Llvm\\**\\lib",
+    "C:\\MSYS*\\MinGW*\\lib",
+    "C:\\Program Files*\\LLVM\\lib",
+    "C:\\LLVM\\lib",
 ];
 
 /// `libclang` directory patterns for illumos
 const DIRECTORIES_ILLUMOS: &[&str] = &[
-    "/opt/ooce/clang-*/lib",
     "/opt/ooce/llvm-*/lib",
+    "/opt/ooce/clang-*/lib",
 ];
 
 //================================================
@@ -328,7 +335,7 @@ pub fn search_libclang_directories(filenames: &[String], variable: &str) -> Vec<
     let mut options = MatchOptions::new();
     options.case_sensitive = false;
     options.require_literal_separator = true;
-    for directory in directories.iter().rev() {
+    for directory in directories.iter() {
         if let Ok(directories) = glob::glob_with(directory, options) {
             for directory in directories.filter_map(Result::ok).filter(|p| p.is_dir()) {
                 found.extend(search_directories(&directory, filenames));

--- a/build/common.rs
+++ b/build/common.rs
@@ -91,9 +91,19 @@ impl Drop for CommandErrorPrinter {
     }
 }
 
+#[cfg(test)]
+pub static RUN_COMMAND_MOCK: std::sync::Mutex<
+    Option<Box<dyn Fn(&str, &str, &[&str]) -> Option<String> + Send + Sync + 'static>>,
+> = std::sync::Mutex::new(None);
+
 /// Executes a command and returns the `stdout` output if the command was
 /// successfully executed (errors are added to `COMMAND_ERRORS`).
 fn run_command(name: &str, path: &str, arguments: &[&str]) -> Option<String> {
+    #[cfg(test)]
+    if let Some(command) = &*RUN_COMMAND_MOCK.lock().unwrap() {
+        return command(name, path, arguments);
+    }
+
     let output = match Command::new(path).args(arguments).output() {
         Ok(output) => output,
         Err(error) => {
@@ -233,7 +243,7 @@ fn search_directories(directory: &Path, filenames: &[String]) -> Vec<(PathBuf, S
     // keep things consistent with other platforms, only LLVM `lib` directories
     // are included in the backup search directory globs so we need to search
     // the LLVM `bin` directory here.
-    if cfg!(target_os = "windows") && directory.ends_with("lib") {
+    if os!("windows") && directory.ends_with("lib") {
         let sibling = directory.parent().unwrap().join("bin");
         results.extend(search_directory(&sibling, filenames).into_iter());
     }
@@ -273,7 +283,7 @@ pub fn search_libclang_directories(filenames: &[String], variable: &str) -> Vec<
 
     // Search the toolchain directory in the directory returned by
     // `xcode-select --print-path`.
-    if cfg!(target_os = "macos") {
+    if os!("macos") {
         if let Some(output) = run_xcode_select(&["--print-path"]) {
             let directory = Path::new(output.lines().next().unwrap()).to_path_buf();
             let directory = directory.join("Toolchains/XcodeDefault.xctoolchain/usr/lib");
@@ -289,18 +299,29 @@ pub fn search_libclang_directories(filenames: &[String], variable: &str) -> Vec<
     }
 
     // Determine the `libclang` directory patterns.
-    let directories = if cfg!(target_os = "haiku") {
+    let directories = if os!("haiku") {
         DIRECTORIES_HAIKU
-    } else if cfg!(any(target_os = "linux", target_os = "freebsd")) {
+    } else if os!("linux") || os!("freebsd") {
         DIRECTORIES_LINUX
-    } else if cfg!(target_os = "macos") {
+    } else if os!("macos") {
         DIRECTORIES_MACOS
-    } else if cfg!(target_os = "windows") {
+    } else if os!("windows") {
         DIRECTORIES_WINDOWS
-    } else if cfg!(target_os = "illumos") {
+    } else if os!("illumos") {
         DIRECTORIES_ILLUMOS
     } else {
         &[]
+    };
+
+    // We use temporary directories when testing the build script so we'll
+    // remove the prefixes that make the directories absolute.
+    let directories = if test!() {
+        directories
+            .iter()
+            .map(|d| d.strip_prefix('/').or_else(|| d.strip_prefix("C:\\")).unwrap_or(d))
+            .collect::<Vec<_>>()
+    } else {
+        directories.into()
     };
 
     // Search the directories provided by the `libclang` directory patterns.

--- a/build/macros.rs
+++ b/build/macros.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+
+macro_rules! test {
+    () => (cfg!(test) && ::std::env::var("_CLANG_SYS_TEST").is_ok());
+}
+
+macro_rules! os {
+    ($os:expr) => {
+        if cfg!(test) && ::std::env::var("_CLANG_SYS_TEST").is_ok() {
+            let var = ::std::env::var("_CLANG_SYS_TEST_OS");
+            var.map_or(false, |v| v == $os)
+        } else {
+            cfg!(target_os = $os)
+        }
+    };
+}
+
+macro_rules! pointer_width {
+    ($pointer_width:expr) => {
+        if cfg!(test) && ::std::env::var("_CLANG_SYS_TEST").is_ok() {
+            let var = ::std::env::var("_CLANG_SYS_TEST_POINTER_WIDTH");
+            var.map_or(false, |v| v == $pointer_width)
+        } else {
+            cfg!(target_pointer_width = $pointer_width)
+        }
+    };
+}

--- a/build/static.rs
+++ b/build/static.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 
 use glob::Pattern;
 
-use common;
+use super::common;
 
 //================================================
 // Searching
@@ -79,7 +79,7 @@ fn get_clang_libraries<P: AsRef<Path>>(directory: P) -> Vec<String> {
 /// Finds a directory containing LLVM and Clang static libraries and returns the
 /// path to that directory.
 fn find() -> PathBuf {
-    let name = if cfg!(target_os = "windows") {
+    let name = if os!("windows") {
         "libclang.lib"
     } else {
         "libclang.a"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,6 +327,8 @@ cenum! {
         const CXCursor_ConceptSpecializationExpr = 153,
         /// Only produced by `libclang` 15.0 and later.
         const CXCursor_RequiresExpr = 154,
+        /// Only produced by `libclang` 16.0 and later.
+        const CXCursor_CXXParenListInitExpr = 155,
         const CXCursor_UnexposedStmt = 200,
         const CXCursor_LabelStmt = 201,
         const CXCursor_CompoundStmt = 202,
@@ -490,6 +492,8 @@ cenum! {
         const CXCursor_OMPParallelMaskedTaskLoopDirective = 303,
         /// Only produced by `libclang` 15.0 and later.
         const CXCursor_OMPParallelMaskedTaskLoopSimdDirective = 304,
+        /// Only produced by `libclang` 16.0 and later.
+        const CXCursor_OMPErrorDirective = 305,
         #[cfg(not(feature="clang_15_0"))]
         const CXCursor_TranslationUnit = 300,
         #[cfg(feature="clang_15_0")]
@@ -1724,18 +1728,6 @@ pub struct IndexerCallbacks {
 
 default!(IndexerCallbacks);
 
-#[cfg(feature = "clang_16_0")]
-#[derive(Copy, Clone, Debug)]
-#[repr(C)]
-pub struct CXCXXMethodIterator {
-    pub cur: *mut c_void,
-    pub end: *mut c_void,
-    pub tu: CXTranslationUnit,
-}
-
-#[cfg(feature = "clang_16_0")]
-default!(CXCXXMethodIterator);
-
 //================================================
 // Functions
 //================================================
@@ -1764,45 +1756,23 @@ link! {
     #[cfg(feature = "clang_3_8")]
     pub fn clang_CXXField_isMutable(cursor: CXCursor) -> c_uint;
     pub fn clang_CXXMethod_isConst(cursor: CXCursor) -> c_uint;
+    /// Only available on `libclang` 16.0 and later.
+    #[cfg(feature = "clang_16_0")]
+    pub fn clang_CXXMethod_isCopyAssignmentOperator(cursor: CXCursor) -> c_uint;
     /// Only available on `libclang` 3.9 and later.
     #[cfg(feature = "clang_3_9")]
     pub fn clang_CXXMethod_isDefaulted(cursor: CXCursor) -> c_uint;
     /// Only available on `libclang` 16.0 and later.
     #[cfg(feature = "clang_16_0")]
     pub fn clang_CXXMethod_isDeleted(cursor: CXCursor) -> c_uint;
+    /// Only available on `libclang` 16.0 and later.
+    #[cfg(feature = "clang_16_0")]
+    pub fn clang_CXXMethod_isMoveAssignmentOperator(cursor: CXCursor) -> c_uint;
     pub fn clang_CXXMethod_isPureVirtual(cursor: CXCursor) -> c_uint;
     pub fn clang_CXXMethod_isStatic(cursor: CXCursor) -> c_uint;
-    pub fn clang_CXXMethod_isVirtual(cursor: CXCursor) -> c_uint;
     /// Only available on `libclang` 6.0 and later.
     #[cfg(feature = "clang_6_0")]
     pub fn clang_CXXRecord_isAbstract(cursor: CXCursor) -> c_uint;
-    /// Only available on `libclang` 16.0 and later.
-    #[cfg(feature = "clang_16_0")]
-    pub fn clang_CXXRecord_defaultedCopyConstructorIsDeleted(cursor: CXCursor) -> c_uint;
-    /// Only available on `libclang` 16.0 and later.
-    #[cfg(feature = "clang_16_0")]
-    pub fn clang_CXXRecord_defaultedMoveConstructorIsDeleted(cursor: CXCursor) -> c_uint;
-    /// Only available on `libclang` 16.0 and later.
-    #[cfg(feature = "clang_16_0")]
-    pub fn clang_CXXRecord_defaultedDestructorIsDeleted(cursor: CXCursor) -> c_uint;
-    /// Only available on `libclang` 16.0 and later.
-    #[cfg(feature = "clang_16_0")]
-    pub fn clang_CXXRecord_needsImplicitDefaultConstructor(cursor: CXCursor) -> c_uint;
-    /// Only available on `libclang` 16.0 and later.
-    #[cfg(feature = "clang_16_0")]
-    pub fn clang_CXXRecord_needsImplicitCopyConstructor(cursor: CXCursor) -> c_uint;
-    /// Only available on `libclang` 16.0 and later.
-    #[cfg(feature = "clang_16_0")]
-    pub fn clang_CXXRecord_needsImplicitMoveConstructor(cursor: CXCursor) -> c_uint;
-    /// Only available on `libclang` 16.0 and later.
-    #[cfg(feature = "clang_16_0")]
-    pub fn clang_CXXRecord_needsImplicitCopyAssignment(cursor: CXCursor) -> c_uint;
-    /// Only available on `libclang` 16.0 and later.
-    #[cfg(feature = "clang_16_0")]
-    pub fn clang_CXXRecord_needsImplicitMoveAssignment(cursor: CXCursor) -> c_uint;
-    /// Only available on `libclang` 16.0 and later.
-    #[cfg(feature = "clang_16_0")]
-    pub fn clang_CXXRecord_needsImplicitDestructor(cursor: CXCursor) -> c_uint;
     pub fn clang_CompilationDatabase_dispose(database: CXCompilationDatabase);
     pub fn clang_CompilationDatabase_fromDirectory(directory: *const c_char, error: *mut CXCompilationDatabase_Error) -> CXCompilationDatabase;
     pub fn clang_CompilationDatabase_getAllCompileCommands(database: CXCompilationDatabase) -> CXCompileCommands;
@@ -2176,6 +2146,9 @@ link! {
     pub fn clang_getLocation(tu: CXTranslationUnit, file: CXFile, line: c_uint, column: c_uint) -> CXSourceLocation;
     pub fn clang_getLocationForOffset(tu: CXTranslationUnit, file: CXFile, offset: c_uint) -> CXSourceLocation;
     pub fn clang_getModuleForFile(tu: CXTranslationUnit, file: CXFile) -> CXModule;
+    /// Only available on `libclang` 16.0 and later.
+    #[cfg(feature = "clang_16_0")]
+    pub fn clang_getNonReferenceType(type_: CXType) -> CXType;
     pub fn clang_getNullCursor() -> CXCursor;
     pub fn clang_getNullLocation() -> CXSourceLocation;
     pub fn clang_getNullRange() -> CXSourceRange;
@@ -2213,9 +2186,6 @@ link! {
     /// Only available on `libclang` 16.0 and later.
     #[cfg(feature = "clang_16_0")]
     pub fn clang_getUnqualifiedType(type_: CXType) -> CXType;
-    /// Only available on `libclang` 16.0 and later.
-    #[cfg(feature = "clang_16_0")]
-    pub fn clang_getNonReferenceType(type_: CXType) -> CXType;
     pub fn clang_getTypeDeclaration(type_: CXType) -> CXCursor;
     pub fn clang_getTypeKindSpelling(type_: CXTypeKind) -> CXString;
     pub fn clang_getTypeSpelling(type_: CXType) -> CXString;

--- a/src/link.rs
+++ b/src/link.rs
@@ -175,7 +175,9 @@ macro_rules! link {
         /// * a `libclang` shared library could not be found
         /// * the `libclang` shared library could not be opened
         pub fn load_manually() -> Result<SharedLibrary, String> {
+            #[allow(dead_code)]
             mod build {
+                include!(concat!(env!("OUT_DIR"), "/macros.rs"));
                 pub mod common { include!(concat!(env!("OUT_DIR"), "/common.rs")); }
                 pub mod dynamic { include!(concat!(env!("OUT_DIR"), "/dynamic.rs")); }
             }

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -1,0 +1,164 @@
+#![allow(dead_code)]
+
+extern crate glob;
+extern crate tempdir;
+
+use std::collections::HashMap;
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use tempdir::TempDir;
+
+#[macro_use]
+#[path = "../build/macros.rs"]
+mod macros;
+
+#[path = "../build/common.rs"]
+mod common;
+#[path = "../build/dynamic.rs"]
+mod dynamic;
+#[path = "../build/static.rs"]
+mod r#static;
+
+#[derive(Debug, Default)]
+struct RunCommandMock {
+    invocations: Vec<(String, String, Vec<String>)>,
+    responses: HashMap<Vec<String>, String>,
+}
+
+#[derive(Debug)]
+struct Env {
+    os: String,
+    pointer_width: String,
+    vars: HashMap<String, (Option<String>, Option<String>)>,
+    cwd: PathBuf,
+    tmp: TempDir,
+    files: Vec<String>,
+    commands: Arc<Mutex<RunCommandMock>>,
+}
+
+impl Env {
+    fn new(os: &str, pointer_width: &str) -> Self {
+        Env {
+            os: os.into(),
+            pointer_width: pointer_width.into(),
+            vars: HashMap::new(),
+            cwd: env::current_dir().unwrap(),
+            tmp: TempDir::new("clang_sys_test").unwrap(),
+            files: vec![],
+            commands: Default::default(),
+        }
+        .var("CLANG_PATH", None)
+        .var("LD_LIBRARY_PATH", None)
+        .var("LIBCLANG_PATH", None)
+        .var("LIBCLANG_STATIC_PATH", None)
+        .var("LLVM_CONFIG_PATH", None)
+        .var("PATH", None)
+    }
+
+    fn var(mut self, name: &str, value: Option<&str>) -> Self {
+        let previous = env::var(name).ok();
+        self.vars.insert(name.into(), (value.map(|v| v.into()), previous));
+        self
+    }
+
+    fn dir(mut self, path: &str) -> Self {
+        self.files.push(path.into());
+        let path = self.tmp.path().join(path);
+        fs::create_dir_all(path).unwrap();
+        self
+    }
+
+    fn file(mut self, path: &str, contents: &[u8]) -> Self {
+        self.files.push(path.into());
+        let path = self.tmp.path().join(path);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(self.tmp.path().join(path), contents).unwrap();
+        self
+    }
+
+    fn dll(self, path: &str, pointer_width: &str) -> Self {
+        // PE header.
+        let mut contents = [0; 64];
+        contents[0x3C..0x3C + 4].copy_from_slice(&i32::to_le_bytes(10));
+        contents[10..14].copy_from_slice(&[b'P', b'E', 0, 0]);
+        let magic = if pointer_width == "64" { 523 } else { 267 };
+        contents[34..36].copy_from_slice(&u16::to_le_bytes(magic));
+
+        self.file(path, &contents)
+    }
+
+    fn so(self, path: &str, pointer_width: &str) -> Self {
+        // ELF header.
+        let class = if pointer_width == "64" { 2 } else { 1 };
+        let contents = [127, 69, 76, 70, class];
+
+        self.file(path, &contents)
+    }
+
+    fn command(self, command: &str, args: &[&str], response: &str) -> Self {
+        let command = command.to_string();
+        let args = args.iter().map(|a| a.to_string()).collect::<Vec<_>>();
+
+        let mut key = vec![command];
+        key.extend(args);
+        self.commands.lock().unwrap().responses.insert(key, response.into());
+
+        self
+    }
+
+    fn enable(self) -> Self {
+        env::set_var("_CLANG_SYS_TEST", "yep");
+        env::set_var("_CLANG_SYS_TEST_OS", &self.os);
+        env::set_var("_CLANG_SYS_TEST_POINTER_WIDTH", &self.pointer_width);
+
+        for (name, (value, _)) in &self.vars {
+            if let Some(value) = value {
+                env::set_var(name, value);
+            } else {
+                env::remove_var(name);
+            }
+        }
+
+        env::set_current_dir(&self.tmp).unwrap();
+
+        let commands = self.commands.clone();
+        let mock = &mut *common::RUN_COMMAND_MOCK.lock().unwrap();
+        *mock = Some(Box::new(move |command, path, args| {
+            let command = command.to_string();
+            let path = path.to_string();
+            let args = args.iter().map(|a| a.to_string()).collect::<Vec<_>>();
+
+            let mut commands = commands.lock().unwrap();
+            commands.invocations.push((command.clone(), path, args.clone()));
+
+            let mut key = vec![command];
+            key.extend(args);
+            commands.responses.get(&key).cloned()
+        }));
+
+        self
+    }
+}
+
+impl Drop for Env {
+    fn drop(&mut self) {
+        env::remove_var("_CLANG_SYS_TEST");
+        env::remove_var("_CLANG_SYS_TEST_OS");
+
+        for (name, (_, previous)) in &self.vars {
+            if let Some(previous) = previous {
+                env::set_var(name, previous);
+            } else {
+                env::remove_var(name);
+            }
+        }
+
+        if let Err(error) = env::set_current_dir(&self.cwd) {
+            println!("Failed to reset working directory: {:?}", error);
+        }
+    }
+}

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -169,6 +169,52 @@ impl Drop for Env {
 // Dynamic
 //================================================
 
+// Linux -----------------------------------------
+
+#[test]
+#[serial]
+fn test_linux_directory_preference() {
+    let _env = Env::new("linux", "64")
+        .so("usr/lib/libclang.so.1", "64")
+        .so("usr/local/lib/libclang.so.1", "64")
+        .enable();
+
+    assert_eq!(
+        dynamic::find(true),
+        Ok(("usr/local/lib".into(), "libclang.so.1".into())),
+    );
+}
+
+#[test]
+#[serial]
+fn test_linux_version_preference() {
+    let _env = Env::new("linux", "64")
+        .so("usr/lib/libclang-3.so", "64")
+        .so("usr/lib/libclang-3.5.so", "64")
+        .so("usr/lib/libclang-3.5.0.so", "64")
+        .enable();
+
+    assert_eq!(
+        dynamic::find(true),
+        Ok(("usr/lib".into(), "libclang-3.5.0.so".into())),
+    );
+}
+
+#[test]
+#[serial]
+fn test_linux_directory_and_version_preference() {
+    let _env = Env::new("linux", "64")
+        .so("usr/local/llvm/lib/libclang-3.so", "64")
+        .so("usr/local/lib/libclang-3.5.so", "64")
+        .so("usr/lib/libclang-3.5.0.so", "64")
+        .enable();
+
+    assert_eq!(
+        dynamic::find(true),
+        Ok(("usr/lib".into(), "libclang-3.5.0.so".into())),
+    );
+}
+
 // Windows ---------------------------------------
 
 #[test]

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -217,6 +217,7 @@ fn test_linux_directory_and_version_preference() {
 
 // Windows ---------------------------------------
 
+#[cfg(target_os = "windows")]
 #[test]
 #[serial]
 fn test_windows_bin_sibling() {

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 extern crate glob;
+extern crate serial_test;
 extern crate tempdir;
 
 use std::collections::HashMap;
@@ -10,6 +11,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use serial_test::serial;
 use tempdir::TempDir;
 
 #[macro_use]
@@ -170,6 +172,7 @@ impl Drop for Env {
 // Windows ---------------------------------------
 
 #[test]
+#[serial]
 fn test_windows_bin_sibling() {
     let _env = Env::new("windows", "64")
         .dir("Program Files\\LLVM\\lib")

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -162,3 +162,22 @@ impl Drop for Env {
         }
     }
 }
+
+//================================================
+// Dynamic
+//================================================
+
+// Windows ---------------------------------------
+
+#[test]
+fn test_windows_bin_sibling() {
+    let _env = Env::new("windows", "64")
+        .dir("Program Files\\LLVM\\lib")
+        .dll("Program Files\\LLVM\\bin\\libclang.dll", "64")
+        .enable();
+
+    assert_eq!(
+        dynamic::find(true),
+        Ok(("Program Files\\LLVM\\bin".into(), "libclang.dll".into())),
+    );
+}


### PR DESCRIPTION
- Adds support for Clang 16.x
- Fixes #152 by changing Windows search directory order
- Bump MSRV to 1.51.0
- Adds ability to test `libclang` finding code