### PR TITLE
Restore clang_CXXMethod_isVirtual()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1770,6 +1770,7 @@ link! {
     pub fn clang_CXXMethod_isMoveAssignmentOperator(cursor: CXCursor) -> c_uint;
     pub fn clang_CXXMethod_isPureVirtual(cursor: CXCursor) -> c_uint;
     pub fn clang_CXXMethod_isStatic(cursor: CXCursor) -> c_uint;
+    pub fn clang_CXXMethod_isVirtual(cursor: CXCursor) -> c_uint;
     /// Only available on `libclang` 6.0 and later.
     #[cfg(feature = "clang_6_0")]
     pub fn clang_CXXRecord_isAbstract(cursor: CXCursor) -> c_uint;


### PR DESCRIPTION
This pull request is an attempt to fix #154

As suggested in https://github.com/KyleMayes/clang-sys/issues/154#issuecomment-1418334604, I believe this line was just mistakenly deleted, considering `isVirtual()` still exists in the latest development version of Clang ([ref](https://clang.llvm.org/doxygen/classclang_1_1CXXMethodDecl.html#a1f488b7521f08ced46dce05c44cab5c5)). I have almost no knowledge both about clang itself and about clang-sys, but I'm creating this in the hope the fix would be this easy... (Sorry if I'm wrong)