### PR TITLE
Test clang-sys by compiling and using bindgen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,8 @@ jobs:
         with:
           command: test
           args: --verbose --features "${{ matrix.clang[1] }} runtime" -- --nocapture
+      - name: Cargo Run (bindgen-test)
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: --manifest-path bindgen-test/Cargo.toml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .docs/
+bindgen-test/target/
 target/
 
 Cargo.lock

--- a/bindgen-test/Cargo.toml
+++ b/bindgen-test/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+
+name = "clang-sys-bindgen-test"
+authors = ["Kyle Mayes <kyle@mayeses.com>"]
+
+version = "1.5.1"
+
+readme = "README.md"
+license = "Apache-2.0"
+
+description = "Tests clang-sys by compiling and using bindgen."
+
+documentation = "https://docs.rs/clang-sys"
+repository = "https://github.com/KyleMayes/clang-sys"
+
+build = "build.rs"
+
+[build-dependencies]
+
+bindgen = "*"
+
+[patch.crates-io]
+
+clang-sys = { path = ".." }

--- a/bindgen-test/build.rs
+++ b/bindgen-test/build.rs
@@ -1,0 +1,16 @@
+extern crate bindgen;
+
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    println!("cargo:rerun-if-changed=wrapper.h");
+    let out = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindgen::Builder::default()
+        .header("wrapper.h")
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .generate()
+        .expect("Unable to generate bindings!")
+        .write_to_file(out.join("bindings.rs"))
+        .expect("Unable to write bindings!");
+}

--- a/bindgen-test/src/main.rs
+++ b/bindgen-test/src/main.rs
@@ -1,0 +1,10 @@
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+fn main() {
+    let structure = Structure { foo: 322, bar: 6.44 };
+    println!("{:?}", structure);
+}

--- a/bindgen-test/wrapper.h
+++ b/bindgen-test/wrapper.h
@@ -1,0 +1,4 @@
+struct Structure {
+    int foo;
+    float bar;
+};


### PR DESCRIPTION
I'm pretty sure 99.9% of the users of this crate are using it transitively through bindgen so I think it makes sense to make sure any changes are compatible with bindgen. This would have prevented the breakage described in #154