### PR TITLE
replace tempdir with tempfile, since tempdir is deprecated

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ glob = "0.3"
 
 glob = "0.3"
 serial_test = "1"
-tempdir = "0.3"
+tempfile = "3"
 
 [package.metadata.docs.rs]
 

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -2,7 +2,7 @@
 
 extern crate glob;
 extern crate serial_test;
-extern crate tempdir;
+extern crate tempfile;
 
 use std::collections::HashMap;
 use std::env;
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use serial_test::serial;
-use tempdir::TempDir;
+use tempfile::TempDir;
 
 #[macro_use]
 #[path = "../build/macros.rs"]
@@ -51,7 +51,7 @@ impl Env {
             env: None,
             vars: HashMap::new(),
             cwd: env::current_dir().unwrap(),
-            tmp: TempDir::new("clang_sys_test").unwrap(),
+            tmp: tempfile::Builder::new().prefix("clang_sys_test").tempdir().unwrap(),
             files: vec![],
             commands: Default::default(),
         }


### PR DESCRIPTION
Deprecation notice is here: https://crates.io/crates/tempdir