### PR TITLE
deps: update to libloading 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ static = []
 
 glob = "0.3"
 libc = { version = "0.2.39", default-features = false }
-libloading = { version = "0.7", optional = true }
+libloading = { version = "0.8", optional = true }
 
 [build-dependencies]
 


### PR DESCRIPTION
`libloading 0.8` has an MSRV of 1.48 so this MR shouldn't change the MSRV for `clang-sys`.