### PR TITLE
Add bindings for Clang 17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ clang_13_0 = ["clang_12_0"]
 clang_14_0 = ["clang_13_0"]
 clang_15_0 = ["clang_14_0"]
 clang_16_0 = ["clang_15_0"]
+clang_17_0 = ["clang_16_0"]
 
 runtime = ["libloading"]
 static = []
@@ -58,4 +59,4 @@ tempfile = "3"
 
 [package.metadata.docs.rs]
 
-features = ["clang_16_0", "runtime"]
+features = ["clang_17_0", "runtime"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1159,20 +1159,21 @@ cenum! {
     /// Only available on `libclang` 17.0 and later.
     #[cfg(feature = "clang_17_0")]
     enum CXUnaryOperatorKind {
-        const CXUnaryOperator_PostInc = 0,
-        const CXUnaryOperator_PostDec = 1,
-        const CXUnaryOperator_PreInc = 2,
-        const CXUnaryOperator_PreDec = 3,
-        const CXUnaryOperator_AddrOf = 4,
-        const CXUnaryOperator_Deref = 5,
-        const CXUnaryOperator_Plus = 6,
-        const CXUnaryOperator_Minus = 7,
-        const CXUnaryOperator_Not = 8,
-        const CXUnaryOperator_LNot = 9,
-        const CXUnaryOperator_Real = 10,
-        const CXUnaryOperator_Imag = 11,
-        const CXUnaryOperator_Extension = 12,
-        const CXUnaryOperator_Coawait = 13,
+        const CXUnaryOperator_Invalid = 0,
+        const CXUnaryOperator_PostInc = 1,
+        const CXUnaryOperator_PostDec = 2,
+        const CXUnaryOperator_PreInc = 3,
+        const CXUnaryOperator_PreDec = 4,
+        const CXUnaryOperator_AddrOf = 5,
+        const CXUnaryOperator_Deref = 6,
+        const CXUnaryOperator_Plus = 7,
+        const CXUnaryOperator_Minus = 8,
+        const CXUnaryOperator_Not = 9,
+        const CXUnaryOperator_LNot = 10,
+        const CXUnaryOperator_Real = 11,
+        const CXUnaryOperator_Imag = 12,
+        const CXUnaryOperator_Extension = 13,
+        const CXUnaryOperator_Coawait = 14,
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,47 @@ cenum! {
 }
 
 cenum! {
+    /// Only available on `libclang` 17.0 and later.
+    #[cfg(feature = "clang_17_0")]
+    enum CXBinaryOperatorKind {
+        const CXBinaryOperator_Invalid = 0,
+        const CXBinaryOperator_PtrMemD = 1,
+        const CXBinaryOperator_PtrMemI = 2,
+        const CXBinaryOperator_Mul = 3,
+        const CXBinaryOperator_Div = 4,
+        const CXBinaryOperator_Rem = 5,
+        const CXBinaryOperator_Add = 6,
+        const CXBinaryOperator_Sub = 7,
+        const CXBinaryOperator_Shl = 8,
+        const CXBinaryOperator_Shr = 9,
+        const CXBinaryOperator_Cmp = 10,
+        const CXBinaryOperator_LT = 11,
+        const CXBinaryOperator_GT = 12,
+        const CXBinaryOperator_LE = 13,
+        const CXBinaryOperator_GE = 14,
+        const CXBinaryOperator_EQ = 15,
+        const CXBinaryOperator_NE = 16,
+        const CXBinaryOperator_And = 17,
+        const CXBinaryOperator_Xor = 18,
+        const CXBinaryOperator_Or = 19,
+        const CXBinaryOperator_LAnd = 20,
+        const CXBinaryOperator_LOr = 21,
+        const CXBinaryOperator_Assign = 22,
+        const CXBinaryOperator_MulAssign = 23,
+        const CXBinaryOperator_DivAssign = 24,
+        const CXBinaryOperator_RemAssign = 25,
+        const CXBinaryOperator_AddAssign = 26,
+        const CXBinaryOperator_SubAssign = 27,
+        const CXBinaryOperator_ShlAssign = 28,
+        const CXBinaryOperator_ShrAssign = 29,
+        const CXBinaryOperator_AndAssign = 30,
+        const CXBinaryOperator_XorAssign = 31,
+        const CXBinaryOperator_OrAssign = 32,
+        const CXBinaryOperator_Comma = 33,
+    }
+}
+
+cenum! {
     enum CXCallingConv {
         const CXCallingConv_Default = 0,
         const CXCallingConv_C = 1,
@@ -137,6 +178,16 @@ cenum! {
         const CXChildVisit_Break = 0,
         const CXChildVisit_Continue = 1,
         const CXChildVisit_Recurse = 2,
+    }
+}
+
+cenum! {
+    /// Only available on `libclang` 17.0 and later.
+    #[cfg(feature = "clang_17_0")]
+    enum CXChoice {
+        const CXChoice_Default = 0,
+        const CXChoice_Enabled = 1,
+        const CXChoice_Disabled = 2,
     }
 }
 
@@ -714,6 +765,22 @@ cenum! {
     }
 }
 
+/// Only available on `libclang` 17.0 and later.
+#[cfg(feature = "clang_17_0")]
+pub type CXIndexOptions_Flags = c_ushort;
+
+/// Only available on `libclang` 17.0 and later.
+#[cfg(feature = "clang_17_0")]
+pub const CXIndexOptions_ExcludeDeclarationsFromPCH: CXIndexOptions_Flags = 1;
+
+/// Only available on `libclang` 17.0 and later.
+#[cfg(feature = "clang_17_0")]
+pub const CXIndexOptions_DisplayDiagnostics: CXIndexOptions_Flags = 2;
+
+/// Only available on `libclang` 17.0 and later.
+#[cfg(feature = "clang_17_0")]
+pub const CXIndexOptions_StorePreamblesInMemory: CXIndexOptions_Flags = 4;
+
 cenum! {
     enum CXLanguageKind {
         const CXLanguage_Invalid = 0,
@@ -1049,7 +1116,7 @@ cenum! {
         /// Only produced by `libclang` 11.0 and later.
         const CXType_Atomic = 177,
         /// Only produced by `libclang` 15.0 and later.
-        const CXType_BTFTagAttributed = 178,
+        const CXType_BTFTagAttributed = 178,        
     }
 }
 
@@ -1086,6 +1153,27 @@ cenum! {
         const CXTypeNullability_Invalid = 3,
         /// Only produced by `libclang` 12.0 and later.
         const CXTypeNullability_NullableResult = 4,
+    }
+}
+
+cenum! {
+    /// Only available on `libclang` 17.0 and later.
+    #[cfg(feature = "clang_17_0")]
+    enum CXUnaryOperatorKind {
+        const CXUnaryOperator_PostInc = 0,
+        const CXUnaryOperator_PostDec = 1,
+        const CXUnaryOperator_PreInc = 2,
+        const CXUnaryOperator_PreDec = 3,
+        const CXUnaryOperator_AddrOf = 4,
+        const CXUnaryOperator_Deref = 5,
+        const CXUnaryOperator_Plus = 6,
+        const CXUnaryOperator_Minus = 7,
+        const CXUnaryOperator_Not = 8,
+        const CXUnaryOperator_LNot = 9,
+        const CXUnaryOperator_Real = 10,
+        const CXUnaryOperator_Imag = 11,
+        const CXUnaryOperator_Extension = 12,
+        const CXUnaryOperator_Coawait = 13,
     }
 }
 
@@ -1594,6 +1682,21 @@ pub struct CXIdxObjCProtocolRefListInfo {
 
 default!(CXIdxObjCProtocolRefListInfo);
 
+#[cfg(feature = "clang_17_0")]
+#[derive(Copy, Clone, Debug)]
+#[repr(C)]
+pub struct CXIndexOptions {
+    pub Size: c_uint,
+    pub ThreadBackgroundPriorityForIndexing: CXChoice,
+    pub ThreadBackgroundPriorityForEditing: CXChoice,
+    pub flags: CXIndexOptions_Flags,
+    pub PreambleStoragePath: *const c_char,
+    pub InvocationEmissionPath: *const c_char,
+}
+
+#[cfg(feature = "clang_17_0")]
+default!(CXIndexOptions);
+
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct CXPlatformAvailability {
@@ -1771,6 +1874,9 @@ link! {
     pub fn clang_CXXMethod_isPureVirtual(cursor: CXCursor) -> c_uint;
     pub fn clang_CXXMethod_isStatic(cursor: CXCursor) -> c_uint;
     pub fn clang_CXXMethod_isVirtual(cursor: CXCursor) -> c_uint;
+    /// Only available on `libclang` 17.0 and later.
+    #[cfg(feature = "clang_17_0")]
+    pub fn clang_CXXMethod_isExplicit(cursor: CXCursor) -> c_uint;
     /// Only available on `libclang` 6.0 and later.
     #[cfg(feature = "clang_6_0")]
     pub fn clang_CXXRecord_isAbstract(cursor: CXCursor) -> c_uint;
@@ -2005,6 +2111,9 @@ link! {
     pub fn clang_constructUSR_ObjCProtocol(protocol: *const c_char) -> CXString;
     pub fn clang_createCXCursorSet() -> CXCursorSet;
     pub fn clang_createIndex(exclude: c_int, display: c_int) -> CXIndex;
+    /// Only available on `libclang` 17.0 and later.
+    #[cfg(feature = "clang_17_0")]
+    pub fn clang_createIndexWithOptions(options: CXIndexOptions) -> CXIndex;
     pub fn clang_createTranslationUnit(index: CXIndex, file: *const c_char) -> CXTranslationUnit;
     pub fn clang_createTranslationUnit2(index: CXIndex, file: *const c_char, tu: *mut CXTranslationUnit) -> CXErrorCode;
     pub fn clang_createTranslationUnitFromSourceFile(index: CXIndex, file: *const c_char, n_arguments: c_int, arguments: *const *const c_char, n_unsaved: c_uint, unsaved: *mut CXUnsavedFile) -> CXTranslationUnit;
@@ -2049,6 +2158,9 @@ link! {
     pub fn clang_getArgType(type_: CXType, index: c_uint) -> CXType;
     pub fn clang_getArrayElementType(type_: CXType) -> CXType;
     pub fn clang_getArraySize(type_: CXType) -> c_longlong;
+    /// Only available on `libclang` 17.0 and later.
+    #[cfg(feature = "clang_17_0")]
+    pub fn clang_getBinaryOperatorKindSpelling(kind: CXBinaryOperatorKind) -> CXString;
     pub fn clang_getCString(string: CXString) -> *const c_char;
     pub fn clang_getCXTUResourceUsage(tu: CXTranslationUnit) -> CXTUResourceUsage;
     pub fn clang_getCXXAccessSpecifier(cursor: CXCursor) -> CX_CXXAccessSpecifier;
@@ -2073,6 +2185,9 @@ link! {
     pub fn clang_getCompletionPriority(string: CXCompletionString) -> c_uint;
     pub fn clang_getCursor(tu: CXTranslationUnit, location: CXSourceLocation) -> CXCursor;
     pub fn clang_getCursorAvailability(cursor: CXCursor) -> CXAvailabilityKind;
+    /// Only available on `libclang` 17.0 and later.
+    #[cfg(feature = "clang_17_0")]
+    pub fn clang_getCursorBinaryOperatorKind(cursor: CXCursor) -> CXBinaryOperatorKind;
     pub fn clang_getCursorCompletionString(cursor: CXCursor) -> CXCompletionString;
     pub fn clang_getCursorDefinition(cursor: CXCursor) -> CXCursor;
     pub fn clang_getCursorDisplayName(cursor: CXCursor) -> CXString;
@@ -2102,6 +2217,9 @@ link! {
     #[cfg(feature = "clang_6_0")]
     pub fn clang_getCursorTLSKind(cursor: CXCursor) -> CXTLSKind;
     pub fn clang_getCursorType(cursor: CXCursor) -> CXType;
+    /// Only available on `libclang` 17.0 and later.
+    #[cfg(feature = "clang_17_0")]
+    pub fn clang_getCursorUnaryOperatorKind(cursor: CXCursor) -> CXUnaryOperatorKind;
     pub fn clang_getCursorUSR(cursor: CXCursor) -> CXString;
     /// Only available on `libclang` 3.8 and later.
     #[cfg(feature = "clang_3_8")]
@@ -2184,6 +2302,9 @@ link! {
     /// Only available on `libclang` 5.0 and later.
     #[cfg(feature = "clang_5_0")]
     pub fn clang_getTranslationUnitTargetInfo(tu: CXTranslationUnit) -> CXTargetInfo;
+    /// Only available on `libclang` 17.0 and later.
+    #[cfg(feature = "clang_17_0")]
+    pub fn clang_getUnaryOperatorKindSpelling(kind: CXUnaryOperatorKind) -> CXString;
     /// Only available on `libclang` 16.0 and later.
     #[cfg(feature = "clang_16_0")]
     pub fn clang_getUnqualifiedType(type_: CXType) -> CXType;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,20 @@ pub type CXInclusionVisitor = extern "C" fn(CXFile, *mut CXSourceLocation, c_uin
 
 /// Defines a C enum as a series of constants.
 macro_rules! cenum {
+    (#[repr($ty:ty)] $(#[$meta:meta])* enum $name:ident {
+        $($(#[$vmeta:meta])* const $variant:ident = $value:expr), +,
+    }) => (
+        pub type $name = $ty;
+
+        $($(#[$vmeta])* pub const $variant: $name = $value;)+
+    );
+    (#[repr($ty:ty)] $(#[$meta:meta])* enum $name:ident {
+        $($(#[$vmeta:meta])* const $variant:ident = $value:expr); +;
+    }) => (
+        pub type $name = $ty;
+
+        $($(#[$vmeta])* pub const $variant: $name = $value;)+
+    );
     ($(#[$meta:meta])* enum $name:ident {
         $($(#[$vmeta:meta])* const $variant:ident = $value:expr), +,
     }) => (
@@ -182,6 +196,7 @@ cenum! {
 }
 
 cenum! {
+    #[repr(c_uchar)]
     /// Only available on `libclang` 17.0 and later.
     #[cfg(feature = "clang_17_0")]
     enum CXChoice {
@@ -765,22 +780,6 @@ cenum! {
     }
 }
 
-/// Only available on `libclang` 17.0 and later.
-#[cfg(feature = "clang_17_0")]
-pub type CXIndexOptions_Flags = c_ushort;
-
-/// Only available on `libclang` 17.0 and later.
-#[cfg(feature = "clang_17_0")]
-pub const CXIndexOptions_ExcludeDeclarationsFromPCH: CXIndexOptions_Flags = 1;
-
-/// Only available on `libclang` 17.0 and later.
-#[cfg(feature = "clang_17_0")]
-pub const CXIndexOptions_DisplayDiagnostics: CXIndexOptions_Flags = 2;
-
-/// Only available on `libclang` 17.0 and later.
-#[cfg(feature = "clang_17_0")]
-pub const CXIndexOptions_StorePreamblesInMemory: CXIndexOptions_Flags = 4;
-
 cenum! {
     enum CXLanguageKind {
         const CXLanguage_Invalid = 0,
@@ -1286,6 +1285,17 @@ cenum! {
         const CXIndexOptIndexImplicitTemplateInstantiations = 4;
         const CXIndexOptSuppressWarnings = 8;
         const CXIndexOptSkipParsedBodiesInSession = 16;
+    }
+}
+
+cenum! {
+    #[repr(c_ushort)]
+    /// Only available on `libclang` 17.0 and later.
+    #[cfg(feature = "clang_17_0")]
+    enum CXIndexOptions_Flags {
+        const CXIndexOptions_ExcludeDeclarationsFromPCH = 0;
+        const CXIndexOptions_DisplayDiagnostics = 1;
+        const CXIndexOptions_StorePreamblesInMemory = 2;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1288,16 +1288,27 @@ cenum! {
     }
 }
 
-cenum! {
-    #[repr(c_ushort)]
-    /// Only available on `libclang` 17.0 and later.
-    #[cfg(feature = "clang_17_0")]
-    enum CXIndexOptions_Flags {
-        const CXIndexOptions_ExcludeDeclarationsFromPCH = 0;
-        const CXIndexOptions_DisplayDiagnostics = 1;
-        const CXIndexOptions_StorePreamblesInMemory = 2;
-    }
-}
+/// Only available on `libclang` 17.0 and later.
+#[cfg(feature = "clang_17_0")]
+#[cfg(not(target_os = "windows"))]
+pub type CXIndexOptions_Flags = c_ushort;
+
+/// Only available on `libclang` 17.0 and later.
+#[cfg(feature = "clang_17_0")]
+#[cfg(target_os = "windows")]
+pub type CXIndexOptions_Flags = c_uint;
+
+/// Only available on `libclang` 17.0 and later.
+#[cfg(feature = "clang_17_0")]
+pub const CXIndexOptions_ExcludeDeclarationsFromPCH: CXIndexOptions_Flags = 1;
+
+/// Only available on `libclang` 17.0 and later.
+#[cfg(feature = "clang_17_0")]
+pub const CXIndexOptions_DisplayDiagnostics: CXIndexOptions_Flags = 2;
+
+/// Only available on `libclang` 17.0 and later.
+#[cfg(feature = "clang_17_0")]
+pub const CXIndexOptions_StorePreamblesInMemory: CXIndexOptions_Flags = 4;
 
 cenum! {
     enum CXNameRefFlags {

--- a/src/link.rs
+++ b/src/link.rs
@@ -191,7 +191,7 @@ https://docs.rs/clang-sys/latest/clang_sys/{0}/index.html
 
 Instructions for installing `libclang` can be found here:
 https://rust-lang.github.io/rust-bindgen/requirements.html
-"#,
+"#, 
                             stringify!($name),
                             library
                                 .version()

--- a/src/link.rs
+++ b/src/link.rs
@@ -62,6 +62,7 @@ macro_rules! link {
             V11_0 = 110,
             V12_0 = 120,
             V16_0 = 160,
+            V17_0 = 170,
         }
 
         impl fmt::Display for Version {
@@ -81,7 +82,8 @@ macro_rules! link {
                     V9_0 => write!(f, "9.0.x - 10.0.x"),
                     V11_0 => write!(f, "11.0.x"),
                     V12_0 => write!(f, "12.0.x - 15.0.x"),
-                    V16_0 => write!(f, "16.0.x or later"),
+                    V16_0 => write!(f, "16.0.x"),
+                    V17_0 => write!(f, "17.0.x or later"),
                 }
             }
         }
@@ -130,6 +132,7 @@ macro_rules! link {
                 }
 
                 unsafe {
+                    check!(b"clang_CXXMethod_isExplicit", V17_0);
                     check!(b"clang_CXXMethod_isCopyAssignmentOperator", V16_0);
                     check!(b"clang_Cursor_getVarDeclInitializer", V12_0);
                     check!(b"clang_Type_getValueType", V11_0);
@@ -188,7 +191,7 @@ https://docs.rs/clang-sys/latest/clang_sys/{0}/index.html
 
 Instructions for installing `libclang` can be found here:
 https://rust-lang.github.io/rust-bindgen/requirements.html
-"#, 
+"#,
                             stringify!($name),
                             library
                                 .version()


### PR DESCRIPTION
Clang 17.0.1 Release notes: https://releases.llvm.org/17.0.1/tools/clang/docs/ReleaseNotes.html#libclang

If it can be useful, here is the output of
`git diff llvmorg-16.0.1 llvmorg-17.0.1 -- clang/include/clang-c/Index.h`:
```diff
diff --git a/clang/include/clang-c/Index.h b/clang/include/clang-c/Index.h
index a3e54285f89f..601b91f67d65 100644
--- a/clang/include/clang-c/Index.h
+++ b/clang/include/clang-c/Index.h
@@ -34,7 +34,7 @@
  * compatible, thus CINDEX_VERSION_MAJOR is expected to remain stable.
  */
 #define CINDEX_VERSION_MAJOR 0
-#define CINDEX_VERSION_MINOR 63
+#define CINDEX_VERSION_MINOR 64
 
 #define CINDEX_VERSION_ENCODE(major, minor) (((major)*10000) + ((minor)*1))
 
@@ -48,6 +48,10 @@
 #define CINDEX_VERSION_STRING                                                  \
   CINDEX_VERSION_STRINGIZE(CINDEX_VERSION_MAJOR, CINDEX_VERSION_MINOR)
 
+#ifndef __has_feature
+#define __has_feature(feature) 0
+#endif
+
 LLVM_CLANG_C_EXTERN_C_BEGIN
 
 /** \defgroup CINDEX libclang: C Interface to Clang
@@ -275,6 +279,22 @@ CINDEX_LINKAGE CXIndex clang_createIndex(int excludeDeclarationsFromPCH,
  */
 CINDEX_LINKAGE void clang_disposeIndex(CXIndex index);
 
+typedef enum {
+  /**
+   * Use the default value of an option that may depend on the process
+   * environment.
+   */
+  CXChoice_Default = 0,
+  /**
+   * Enable the option.
+   */
+  CXChoice_Enabled = 1,
+  /**
+   * Disable the option.
+   */
+  CXChoice_Disabled = 2
+} CXChoice;
+
 typedef enum {
   /**
    * Used to indicate that no special CXIndex options are needed.
@@ -309,9 +329,131 @@ typedef enum {
 
 } CXGlobalOptFlags;
 
+/**
+ * Index initialization options.
+ *
+ * 0 is the default value of each member of this struct except for Size.
+ * Initialize the struct in one of the following three ways to avoid adapting
+ * code each time a new member is added to it:
+ * \code
+ * CXIndexOptions Opts;
+ * memset(&Opts, 0, sizeof(Opts));
+ * Opts.Size = sizeof(CXIndexOptions);
+ * \endcode
+ * or explicitly initialize the first data member and zero-initialize the rest:
+ * \code
+ * CXIndexOptions Opts = { sizeof(CXIndexOptions) };
+ * \endcode
+ * or to prevent the -Wmissing-field-initializers warning for the above version:
+ * \code
+ * CXIndexOptions Opts{};
+ * Opts.Size = sizeof(CXIndexOptions);
+ * \endcode
+ */
+typedef struct CXIndexOptions {
+  /**
+   * The size of struct CXIndexOptions used for option versioning.
+   *
+   * Always initialize this member to sizeof(CXIndexOptions), or assign
+   * sizeof(CXIndexOptions) to it right after creating a CXIndexOptions object.
+   */
+  unsigned Size;
+  /**
+   * A CXChoice enumerator that specifies the indexing priority policy.
+   * \sa CXGlobalOpt_ThreadBackgroundPriorityForIndexing
+   */
+  unsigned char ThreadBackgroundPriorityForIndexing;
+  /**
+   * A CXChoice enumerator that specifies the editing priority policy.
+   * \sa CXGlobalOpt_ThreadBackgroundPriorityForEditing
+   */
+  unsigned char ThreadBackgroundPriorityForEditing;
+  /**
+   * \see clang_createIndex()
+   */
+  unsigned ExcludeDeclarationsFromPCH : 1;
+  /**
+   * \see clang_createIndex()
+   */
+  unsigned DisplayDiagnostics : 1;
+  /**
+   * Store PCH in memory. If zero, PCH are stored in temporary files.
+   */
+  unsigned StorePreamblesInMemory : 1;
+  unsigned /*Reserved*/ : 13;
+
+  /**
+   * The path to a directory, in which to store temporary PCH files. If null or
+   * empty, the default system temporary directory is used. These PCH files are
+   * deleted on clean exit but stay on disk if the program crashes or is killed.
+   *
+   * This option is ignored if \a StorePreamblesInMemory is non-zero.
+   *
+   * Libclang does not create the directory at the specified path in the file
+   * system. Therefore it must exist, or storing PCH files will fail.
+   */
+  const char *PreambleStoragePath;
+  /**
+   * Specifies a path which will contain log files for certain libclang
+   * invocations. A null value implies that libclang invocations are not logged.
+   */
+  const char *InvocationEmissionPath;
+} CXIndexOptions;
+
+/**
+ * Provides a shared context for creating translation units.
+ *
+ * Call this function instead of clang_createIndex() if you need to configure
+ * the additional options in CXIndexOptions.
+ *
+ * \returns The created index or null in case of error, such as an unsupported
+ * value of options->Size.
+ *
+ * For example:
+ * \code
+ * CXIndex createIndex(const char *ApplicationTemporaryPath) {
+ *   const int ExcludeDeclarationsFromPCH = 1;
+ *   const int DisplayDiagnostics = 1;
+ *   CXIndex Idx;
+ * #if CINDEX_VERSION_MINOR >= 64
+ *   CXIndexOptions Opts;
+ *   memset(&Opts, 0, sizeof(Opts));
+ *   Opts.Size = sizeof(CXIndexOptions);
+ *   Opts.ThreadBackgroundPriorityForIndexing = 1;
+ *   Opts.ExcludeDeclarationsFromPCH = ExcludeDeclarationsFromPCH;
+ *   Opts.DisplayDiagnostics = DisplayDiagnostics;
+ *   Opts.PreambleStoragePath = ApplicationTemporaryPath;
+ *   Idx = clang_createIndexWithOptions(&Opts);
+ *   if (Idx)
+ *     return Idx;
+ *   fprintf(stderr,
+ *           "clang_createIndexWithOptions() failed. "
+ *           "CINDEX_VERSION_MINOR = %d, sizeof(CXIndexOptions) = %u\n",
+ *           CINDEX_VERSION_MINOR, Opts.Size);
+ * #else
+ *   (void)ApplicationTemporaryPath;
+ * #endif
+ *   Idx = clang_createIndex(ExcludeDeclarationsFromPCH, DisplayDiagnostics);
+ *   clang_CXIndex_setGlobalOptions(
+ *       Idx, clang_CXIndex_getGlobalOptions(Idx) |
+ *                CXGlobalOpt_ThreadBackgroundPriorityForIndexing);
+ *   return Idx;
+ * }
+ * \endcode
+ *
+ * \sa clang_createIndex()
+ */
+CINDEX_LINKAGE CXIndex
+clang_createIndexWithOptions(const CXIndexOptions *options);
+
 /**
  * Sets general options associated with a CXIndex.
  *
+ * This function is DEPRECATED. Set
+ * CXIndexOptions::ThreadBackgroundPriorityForIndexing and/or
+ * CXIndexOptions::ThreadBackgroundPriorityForEditing and call
+ * clang_createIndexWithOptions() instead.
+ *
  * For example:
  * \code
  * CXIndex idx = ...;
@@ -327,6 +469,9 @@ CINDEX_LINKAGE void clang_CXIndex_setGlobalOptions(CXIndex, unsigned options);
 /**
  * Gets the general options associated with a CXIndex.
  *
+ * This function allows to obtain the final option values used by libclang after
+ * specifying the option policies via CXChoice enumerators.
+ *
  * \returns A bitmask of options, a bitwise OR of CXGlobalOpt_XXX flags that
  * are associated with the given CXIndex object.
  */
@@ -335,6 +480,9 @@ CINDEX_LINKAGE unsigned clang_CXIndex_getGlobalOptions(CXIndex);
 /**
  * Sets the invocation emission path option in a CXIndex.
  *
+ * This function is DEPRECATED. Set CXIndexOptions::InvocationEmissionPath and
+ * call clang_createIndexWithOptions() instead.
+ *
  * The invocation emission path specifies a path which will contain log
  * files for certain libclang invocations. A null value (default) implies that
  * libclang invocations are not logged..
@@ -2787,10 +2935,15 @@ enum CXTypeKind {
   CXType_OCLIntelSubgroupAVCImeResult = 169,
   CXType_OCLIntelSubgroupAVCRefResult = 170,
   CXType_OCLIntelSubgroupAVCSicResult = 171,
+  CXType_OCLIntelSubgroupAVCImeResultSingleReferenceStreamout = 172,
+  CXType_OCLIntelSubgroupAVCImeResultDualReferenceStreamout = 173,
+  CXType_OCLIntelSubgroupAVCImeSingleReferenceStreamin = 174,
+  CXType_OCLIntelSubgroupAVCImeDualReferenceStreamin = 175,
+
+  /* Old aliases for AVC OpenCL extension types. */
   CXType_OCLIntelSubgroupAVCImeResultSingleRefStreamout = 172,
   CXType_OCLIntelSubgroupAVCImeResultDualRefStreamout = 173,
   CXType_OCLIntelSubgroupAVCImeSingleRefStreamin = 174,
-
   CXType_OCLIntelSubgroupAVCImeDualRefStreamin = 175,
 
   CXType_ExtVector = 176,
@@ -2888,9 +3041,25 @@ CINDEX_LINKAGE unsigned long long
 clang_getEnumConstantDeclUnsignedValue(CXCursor C);
 
 /**
- * Retrieve the bit width of a bit field declaration as an integer.
+ * Returns non-zero if the cursor specifies a Record member that is a bit-field.
+ */
+CINDEX_LINKAGE unsigned clang_Cursor_isBitField(CXCursor C);
+
+/**
+ * Retrieve the bit width of a bit-field declaration as an integer.
+ *
+ * If the cursor does not reference a bit-field, or if the bit-field's width
+ * expression cannot be evaluated, -1 is returned.
  *
- * If a cursor that is not a bit field declaration is passed in, -1 is returned.
+ * For example:
+ * \code
+ * if (clang_Cursor_isBitField(Cursor)) {
+ *   int Width = clang_getFieldDeclBitWidth(Cursor);
+ *   if (Width != -1) {
+ *     // The bit-field width is not value-dependent.
+ *   }
+ * }
+ * \endcode
  */
 CINDEX_LINKAGE int clang_getFieldDeclBitWidth(CXCursor C);
 
@@ -3519,12 +3688,6 @@ CINDEX_LINKAGE CXType clang_Type_getTemplateArgumentAsType(CXType T,
  */
 CINDEX_LINKAGE enum CXRefQualifierKind clang_Type_getCXXRefQualifier(CXType T);
 
-/**
- * Returns non-zero if the cursor specifies a Record member that is a
- *   bitfield.
- */
-CINDEX_LINKAGE unsigned clang_Cursor_isBitField(CXCursor C);
-
 /**
  * Returns 1 if the base class specified by the cursor with kind
  *   CX_CXXBaseSpecifier is virtual.
@@ -3697,8 +3860,6 @@ typedef enum CXChildVisitResult (*CXCursorVisitor)(CXCursor cursor,
 CINDEX_LINKAGE unsigned clang_visitChildren(CXCursor parent,
                                             CXCursorVisitor visitor,
                                             CXClientData client_data);
-#ifdef __has_feature
-#if __has_feature(blocks)
 /**
  * Visitor invoked for each cursor found by a traversal.
  *
@@ -3709,8 +3870,12 @@ CINDEX_LINKAGE unsigned clang_visitChildren(CXCursor parent,
  * The visitor should return one of the \c CXChildVisitResult values
  * to direct clang_visitChildrenWithBlock().
  */
+#if __has_feature(blocks)
 typedef enum CXChildVisitResult (^CXCursorVisitorBlock)(CXCursor cursor,
                                                         CXCursor parent);
+#else
+typedef struct _CXChildVisitResult *CXCursorVisitorBlock;
+#endif
 
 /**
  * Visits the children of a cursor using the specified block.  Behaves
@@ -3718,8 +3883,6 @@ typedef enum CXChildVisitResult (^CXCursorVisitorBlock)(CXCursor cursor,
  */
 CINDEX_LINKAGE unsigned
 clang_visitChildrenWithBlock(CXCursor parent, CXCursorVisitorBlock block);
-#endif
-#endif
 
 /**
  * @}
@@ -4343,6 +4506,51 @@ CINDEX_LINKAGE unsigned clang_CXXMethod_isCopyAssignmentOperator(CXCursor C);
  */
 CINDEX_LINKAGE unsigned clang_CXXMethod_isMoveAssignmentOperator(CXCursor C);
 
+/**
+ * Determines if a C++ constructor or conversion function was declared
+ * explicit, returning 1 if such is the case and 0 otherwise.
+ *
+ * Constructors or conversion functions are declared explicit through
+ * the use of the explicit specifier.
+ *
+ * For example, the following constructor and conversion function are
+ * not explicit as they lack the explicit specifier:
+ *
+ *     class Foo {
+ *         Foo();
+ *         operator int();
+ *     };
+ *
+ * While the following constructor and conversion function are
+ * explicit as they are declared with the explicit specifier.
+ *
+ *     class Foo {
+ *         explicit Foo();
+ *         explicit operator int();
+ *     };
+ *
+ * This function will return 0 when given a cursor pointing to one of
+ * the former declarations and it will return 1 for a cursor pointing
+ * to the latter declarations.
+ *
+ * The explicit specifier allows the user to specify a
+ * conditional compile-time expression whose value decides
+ * whether the marked element is explicit or not.
+ *
+ * For example:
+ *
+ *     constexpr bool foo(int i) { return i % 2 == 0; }
+ *
+ *     class Foo {
+ *          explicit(foo(1)) Foo();
+ *          explicit(foo(2)) operator int();
+ *     }
+ *
+ * This function will return 0 for the constructor and 1 for
+ * the conversion function.
+ */
+CINDEX_LINKAGE unsigned clang_CXXMethod_isExplicit(CXCursor C);
+
 /**
  * Determine if a C++ record is abstract, i.e. whether a class or struct
  * has a pure virtual member function.
@@ -5675,11 +5883,12 @@ CINDEX_LINKAGE CXResult clang_findReferencesInFile(
 CINDEX_LINKAGE CXResult clang_findIncludesInFile(
     CXTranslationUnit TU, CXFile file, CXCursorAndRangeVisitor visitor);
 
-#ifdef __has_feature
 #if __has_feature(blocks)
-
 typedef enum CXVisitorResult (^CXCursorAndRangeVisitorBlock)(CXCursor,
                                                              CXSourceRange);
+#else
+typedef struct _CXCursorAndRangeVisitorBlock *CXCursorAndRangeVisitorBlock;
+#endif
 
 CINDEX_LINKAGE
 CXResult clang_findReferencesInFileWithBlock(CXCursor, CXFile,
@@ -5689,9 +5898,6 @@ CINDEX_LINKAGE
 CXResult clang_findIncludesInFileWithBlock(CXTranslationUnit, CXFile,
                                            CXCursorAndRangeVisitorBlock);
 
-#endif
-#endif
-
 /**
  * The client's data object that is associated with a CXFile.
  */
@@ -6304,6 +6510,144 @@ typedef enum CXVisitorResult (*CXFieldVisitor)(CXCursor C,
 CINDEX_LINKAGE unsigned clang_Type_visitFields(CXType T, CXFieldVisitor visitor,
                                                CXClientData client_data);
 
+/**
+ * Describes the kind of binary operators.
+ */
+enum CXBinaryOperatorKind {
+  /** This value describes cursors which are not binary operators. */
+  CXBinaryOperator_Invalid,
+  /** C++ Pointer - to - member operator. */
+  CXBinaryOperator_PtrMemD,
+  /** C++ Pointer - to - member operator. */
+  CXBinaryOperator_PtrMemI,
+  /** Multiplication operator. */
+  CXBinaryOperator_Mul,
+  /** Division operator. */
+  CXBinaryOperator_Div,
+  /** Remainder operator. */
+  CXBinaryOperator_Rem,
+  /** Addition operator. */
+  CXBinaryOperator_Add,
+  /** Subtraction operator. */
+  CXBinaryOperator_Sub,
+  /** Bitwise shift left operator. */
+  CXBinaryOperator_Shl,
+  /** Bitwise shift right operator. */
+  CXBinaryOperator_Shr,
+  /** C++ three-way comparison (spaceship) operator. */
+  CXBinaryOperator_Cmp,
+  /** Less than operator. */
+  CXBinaryOperator_LT,
+  /** Greater than operator. */
+  CXBinaryOperator_GT,
+  /** Less or equal operator. */
+  CXBinaryOperator_LE,
+  /** Greater or equal operator. */
+  CXBinaryOperator_GE,
+  /** Equal operator. */
+  CXBinaryOperator_EQ,
+  /** Not equal operator. */
+  CXBinaryOperator_NE,
+  /** Bitwise AND operator. */
+  CXBinaryOperator_And,
+  /** Bitwise XOR operator. */
+  CXBinaryOperator_Xor,
+  /** Bitwise OR operator. */
+  CXBinaryOperator_Or,
+  /** Logical AND operator. */
+  CXBinaryOperator_LAnd,
+  /** Logical OR operator. */
+  CXBinaryOperator_LOr,
+  /** Assignment operator. */
+  CXBinaryOperator_Assign,
+  /** Multiplication assignment operator. */
+  CXBinaryOperator_MulAssign,
+  /** Division assignment operator. */
+  CXBinaryOperator_DivAssign,
+  /** Remainder assignment operator. */
+  CXBinaryOperator_RemAssign,
+  /** Addition assignment operator. */
+  CXBinaryOperator_AddAssign,
+  /** Subtraction assignment operator. */
+  CXBinaryOperator_SubAssign,
+  /** Bitwise shift left assignment operator. */
+  CXBinaryOperator_ShlAssign,
+  /** Bitwise shift right assignment operator. */
+  CXBinaryOperator_ShrAssign,
+  /** Bitwise AND assignment operator. */
+  CXBinaryOperator_AndAssign,
+  /** Bitwise XOR assignment operator. */
+  CXBinaryOperator_XorAssign,
+  /** Bitwise OR assignment operator. */
+  CXBinaryOperator_OrAssign,
+  /** Comma operator. */
+  CXBinaryOperator_Comma
+};
+
+/**
+ * Retrieve the spelling of a given CXBinaryOperatorKind.
+ */
+CINDEX_LINKAGE CXString
+clang_getBinaryOperatorKindSpelling(enum CXBinaryOperatorKind kind);
+
+/**
+ * Retrieve the binary operator kind of this cursor.
+ *
+ * If this cursor is not a binary operator then returns Invalid.
+ */
+CINDEX_LINKAGE enum CXBinaryOperatorKind
+clang_getCursorBinaryOperatorKind(CXCursor cursor);
+
+/**
+ * Describes the kind of unary operators.
+ */
+enum CXUnaryOperatorKind {
+  /** This value describes cursors which are not unary operators. */
+  CXUnaryOperator_Invalid,
+  /** Postfix increment operator. */
+  CXUnaryOperator_PostInc,
+  /** Postfix decrement operator. */
+  CXUnaryOperator_PostDec,
+  /** Prefix increment operator. */
+  CXUnaryOperator_PreInc,
+  /** Prefix decrement operator. */
+  CXUnaryOperator_PreDec,
+  /** Address of operator. */
+  CXUnaryOperator_AddrOf,
+  /** Dereference operator. */
+  CXUnaryOperator_Deref,
+  /** Plus operator. */
+  CXUnaryOperator_Plus,
+  /** Minus operator. */
+  CXUnaryOperator_Minus,
+  /** Not operator. */
+  CXUnaryOperator_Not,
+  /** LNot operator. */
+  CXUnaryOperator_LNot,
+  /** "__real expr" operator. */
+  CXUnaryOperator_Real,
+  /** "__imag expr" operator. */
+  CXUnaryOperator_Imag,
+  /** __extension__ marker operator. */
+  CXUnaryOperator_Extension,
+  /** C++ co_await operator. */
+  CXUnaryOperator_Coawait
+};
+
+/**
+ * Retrieve the spelling of a given CXUnaryOperatorKind.
+ */
+CINDEX_LINKAGE CXString
+clang_getUnaryOperatorKindSpelling(enum CXUnaryOperatorKind kind);
+
+/**
+ * Retrieve the unary operator kind of this cursor.
+ *
+ * If this cursor is not a unary operator then returns Invalid.
+ */
+CINDEX_LINKAGE enum CXUnaryOperatorKind
+clang_getCursorUnaryOperatorKind(CXCursor cursor);
+
 /**
  * @}
  */
```