### PR TITLE
Update actions and bump MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         clang: [["14.0", "clang_14_0"]]
-        rust: ["1.51.0"]
+        rust: ["1.60.0"]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         rust: ["1.60.0"]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       # LLVM and Clang
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v1
@@ -28,22 +28,13 @@ jobs:
           directory: ${{ runner.temp }}/llvm-${{ matrix.clang[0] }}
       # Rust
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
       # Test
       - name: Cargo Test (Dynamic)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --features ${{ matrix.clang[1] }} -- --nocapture
+        run: cargo test --verbose --features ${{ matrix.clang[1] }} -- --nocapture
       - name: Cargo Test (Runtime)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --features "${{ matrix.clang[1] }} runtime" -- --nocapture
+        run: cargo test --verbose --features "${{ matrix.clang[1] }} runtime" -- --nocapture
       - name: Cargo Run (bindgen-test)
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --manifest-path bindgen-test/Cargo.toml
+        run: cargo run --manifest-path bindgen-test/Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ on:
       - master
 
 jobs:
-  ci:
-    name: CI
+  test:
+    name: Test
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -36,5 +36,21 @@ jobs:
         run: cargo test --verbose --features ${{ matrix.clang[1] }} -- --nocapture
       - name: Cargo Test (Runtime)
         run: cargo test --verbose --features "${{ matrix.clang[1] }} runtime" -- --nocapture
+  test-bindgen:
+    name: Test (bindgen)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      # LLVM and Clang
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: 14
+          directory: ${{ runner.temp }}/llvm
+      # Rust
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      # Test
       - name: Cargo Run (bindgen-test)
         run: cargo run --manifest-path bindgen-test/Cargo.toml

--- a/.github/workflows/ssh.yml
+++ b/.github/workflows/ssh.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         clang: [["13.0", "clang_13_0"]]
-        rust: ["1.51.0"]
+        rust: ["1.60.0"]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/.github/workflows/ssh.yml
+++ b/.github/workflows/ssh.yml
@@ -30,7 +30,7 @@ jobs:
           directory: ${{ runner.temp }}/llvm-${{ matrix.clang[0] }}
       # Rust
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         if: github.event.inputs.os == matrix.os
         with:
           toolchain: ${{ matrix.rust }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.8.0] - UNRELEASED
+
+### Changed
+- Bumped minimum supported Rust version (MSRV) to 1.60.0
+
 ## [1.7.0] - 2023-12-31
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,8 @@ glob = "0.3"
 [dev-dependencies]
 
 glob = "0.3"
-tempfile = "3"
+lazy_static = "1"
+tempfile = ">=3.0.0, <3.7.0"
 
 [package.metadata.docs.rs]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 
+edition = "2021"
+
 name = "clang-sys"
 authors = ["Kyle Mayes <kyle@mayeses.com>"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,6 @@ glob = "0.3"
 [dev-dependencies]
 
 glob = "0.3"
-serial_test = "1"
 tempfile = "3"
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Crate](https://img.shields.io/crates/v/clang-sys.svg)](https://crates.io/crates/clang-sys)
 [![Documentation](https://docs.rs/clang-sys/badge.svg)](https://docs.rs/clang-sys)
 [![CI](https://img.shields.io/github/actions/workflow/status/KyleMayes/clang-sys/ci.yml?branch=master)](https://github.com/KyleMayes/clang-sys/actions?query=workflow%3ACI)
-![MSRV](https://img.shields.io/badge/MSRV-1.51.0-blue)
+![MSRV](https://img.shields.io/badge/MSRV-1.56.0-blue)
 
 Rust bindings for `libclang`.
 

--- a/bindgen-test/build.rs
+++ b/bindgen-test/build.rs
@@ -8,7 +8,7 @@ fn main() {
     let out = PathBuf::from(env::var("OUT_DIR").unwrap());
     bindgen::Builder::default()
         .header("wrapper.h")
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .generate()
         .expect("Unable to generate bindings!")
         .write_to_file(out.join("bindings.rs"))

--- a/build.rs
+++ b/build.rs
@@ -15,8 +15,6 @@
 
 #![allow(unused_attributes)]
 
-extern crate glob;
-
 use std::path::Path;
 
 #[macro_use]

--- a/build/common.rs
+++ b/build/common.rs
@@ -24,7 +24,7 @@ fn add_command_error(name: &str, path: &str, arguments: &[&str], message: String
     COMMAND_ERRORS.with(|e| {
         e.borrow_mut()
             .entry(name.into())
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(format!(
                 "couldn't execute `{} {}` (path={}) ({})",
                 name,
@@ -255,7 +255,7 @@ fn search_directories(directory: &Path, filenames: &[String]) -> Vec<(PathBuf, S
     // the LLVM `bin` directory here.
     if target_os!("windows") && directory.ends_with("lib") {
         let sibling = directory.parent().unwrap().join("bin");
-        results.extend(search_directory(&sibling, filenames).into_iter());
+        results.extend(search_directory(&sibling, filenames));
     }
 
     results

--- a/build/common.rs
+++ b/build/common.rs
@@ -90,9 +90,11 @@ impl Drop for CommandErrorPrinter {
 }
 
 #[cfg(test)]
-pub static RUN_COMMAND_MOCK: std::sync::Mutex<
-    Option<Box<dyn Fn(&str, &str, &[&str]) -> Option<String> + Send + Sync + 'static>>,
-> = std::sync::Mutex::new(None);
+lazy_static::lazy_static! {
+    pub static ref RUN_COMMAND_MOCK: std::sync::Mutex<
+        Option<Box<dyn Fn(&str, &str, &[&str]) -> Option<String> + Send + Sync + 'static>>,
+    > = std::sync::Mutex::new(None);
+}
 
 /// Executes a command and returns the `stdout` output if the command was
 /// successfully executed (errors are added to `COMMAND_ERRORS`).

--- a/build/common.rs
+++ b/build/common.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-extern crate glob;
-
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::env;

--- a/build/static.rs
+++ b/build/static.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-extern crate glob;
-
 use std::path::{Path, PathBuf};
 
 use glob::Pattern;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,11 +22,6 @@
 #![allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::unreadable_literal))]
 
-extern crate glob;
-extern crate libc;
-#[cfg(feature = "runtime")]
-extern crate libloading;
-
 pub mod support;
 
 #[macro_use]

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
 
 extern crate glob;
-extern crate serial_test;
 extern crate tempfile;
 
 use std::collections::HashMap;
@@ -11,7 +10,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use serial_test::serial;
 use tempfile::TempDir;
 
 #[macro_use]
@@ -177,14 +175,28 @@ impl Drop for Env {
     }
 }
 
+#[test]
+fn test_all() {
+    // Run tests serially since they alter the environment.
+    
+    test_linux_directory_preference();
+    test_linux_version_preference();
+    test_linux_directory_and_version_preference();
+
+    #[cfg(target_os = "windows")]
+    {
+        test_windows_bin_sibling();
+        test_windows_mingw_gnu();
+        test_windows_mingw_msvc();
+    }
+}
+
 //================================================
 // Dynamic
 //================================================
 
 // Linux -----------------------------------------
 
-#[test]
-#[serial]
 fn test_linux_directory_preference() {
     let _env = Env::new("linux", "64")
         .so("usr/lib/libclang.so.1", "64")
@@ -197,8 +209,6 @@ fn test_linux_directory_preference() {
     );
 }
 
-#[test]
-#[serial]
 fn test_linux_version_preference() {
     let _env = Env::new("linux", "64")
         .so("usr/lib/libclang-3.so", "64")
@@ -212,8 +222,6 @@ fn test_linux_version_preference() {
     );
 }
 
-#[test]
-#[serial]
 fn test_linux_directory_and_version_preference() {
     let _env = Env::new("linux", "64")
         .so("usr/local/llvm/lib/libclang-3.so", "64")
@@ -230,8 +238,6 @@ fn test_linux_directory_and_version_preference() {
 // Windows ---------------------------------------
 
 #[cfg(target_os = "windows")]
-#[test]
-#[serial]
 fn test_windows_bin_sibling() {
     let _env = Env::new("windows", "64")
         .dir("Program Files\\LLVM\\lib")
@@ -245,8 +251,6 @@ fn test_windows_bin_sibling() {
 }
 
 #[cfg(target_os = "windows")]
-#[test]
-#[serial]
 fn test_windows_mingw_gnu() {
     let _env = Env::new("windows", "64")
         .env("gnu")
@@ -263,8 +267,6 @@ fn test_windows_mingw_gnu() {
 }
 
 #[cfg(target_os = "windows")]
-#[test]
-#[serial]
 fn test_windows_mingw_msvc() {
     let _env = Env::new("windows", "64")
         .env("msvc")

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -1,8 +1,5 @@
 #![allow(dead_code)]
 
-extern crate glob;
-extern crate tempfile;
-
 use std::collections::HashMap;
 use std::env;
 use std::fs;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,6 +1,3 @@
-extern crate clang_sys;
-extern crate libc;
-
 use std::ptr;
 
 use clang_sys::*;


### PR DESCRIPTION
Remove usage of `actions-rs` actions and update checkout action.

Update MSRV because some dependencies have increased their MSRV (capping it at 1.60.0 since that is the current MSRV of the `bindgen` crate which is the primary consumer of this crate).