### PR TITLE
Fix static linking error for LLVM-17

### DIFF
--- a/build/static.rs
+++ b/build/static.rs
@@ -41,7 +41,7 @@ fn get_library_name(path: &Path) -> Option<String> {
 
 /// Gets the LLVM static libraries required to link to `libclang`.
 fn get_llvm_libraries() -> Vec<String> {
-    common::run_llvm_config(&["--libs"])
+    common::run_llvm_config(&["--libs", "--link-static"])
         .unwrap()
         .split_whitespace()
         .filter_map(|p| {
@@ -54,6 +54,7 @@ fn get_llvm_libraries() -> Vec<String> {
                 get_library_name(Path::new(p))
             }
         })
+        .chain(["zstd".to_string()])
         .collect()
 }
 


### PR DESCRIPTION
_Foreword: this is my first public pr in quite a while, apologies if something is not quite right._

When specifying the static build feature, this crate attempts to link to the library `-lLLVM-17`. However, LLVM does not provide a single static library since it would be too large (500MB!). Therefore, to successfully link against static LLVM, one must append all of the individual libraries, of which there are many.

This PR uses the `llvm-config` tool's `--link-static` flag, which causes it to output each individual static archive. Additionally, the LLVM library uses symbols from `zstd`, which this PR also appends to the linker.