### PR TITLE
Return unescaped paths when searching for library files

### DIFF
--- a/build/common.rs
+++ b/build/common.rs
@@ -237,7 +237,7 @@ fn search_directory(directory: &Path, filenames: &[String]) -> Vec<(PathBuf, Str
                 return None;
             }
 
-            Some((directory.to_owned(), filename.into()))
+            Some((path.parent().unwrap().to_owned(), filename.into()))
         })
         .collect::<Vec<_>>()
 }


### PR DESCRIPTION
There is a bug in #134 where `search_directory` returned the *escaped* directory, which causes errors when it is later passed to `File::open`.

One can reproduce the issue by creating a project using `bindgen` and setting `LIBCLANG_PATH` to a folder containing square brackets (e.g. `/path/to/[foo]bar`). `clang-sys` is able to find the shared libraries inside the `[foo]bar` folder but is unable to actually load the files because the path becomes `/path/to/[[]foo[]]bar/libclang.so`.