### PR TITLE
Put support invocations of clang executable behind a feature.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.8.3] -  UNRELEASED
+### Changed
+- Introduce a feature "support" to guard all interactions with clang executable.
+Enabled by default, for backwards compatibility.
+
 ## [1.8.2] - 2024-05-29
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ links = "clang"
 build = "build.rs"
 
 [features]
+default = ["support"]
 
 clang_3_5 = []
 clang_3_6 = ["clang_3_5"]
@@ -41,10 +42,12 @@ clang_16_0 = ["clang_15_0"]
 clang_17_0 = ["clang_16_0"]
 clang_18_0 = ["clang_17_0"]
 
-runtime = ["libloading"]
+runtime = ["libloading", "support"]
 static = []
 
 libcpp = []
+
+support = []
 
 [dependencies]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@
 #![allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::unreadable_literal))]
 
+// Keep all interactions with the clang executable in this module.
+#[cfg(feature = "support")]
 pub mod support;
 
 #[macro_use]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -38,12 +38,14 @@ fn test() {
     parse();
 }
 
+#[cfg(feature = "support")]
 #[test]
 fn test_support() {
     let clang = support::Clang::find(None, &[]).unwrap();
     println!("{:?}", clang);
 }
 
+#[cfg(feature = "support")]
 #[test]
 fn test_support_target() {
     let args = &["--target".into(), "x86_64-unknown-linux-gnu".into()];
@@ -51,6 +53,7 @@ fn test_support_target() {
     println!("{:?}", clang);
 }
 
+#[cfg(feature = "support")]
 #[cfg(feature = "runtime")]
 #[test]
 fn test_support_runtime() {


### PR DESCRIPTION
This feature can bring client certainty that clang-sys will never invoke the clang executable.

This simplifies integration of tools that depend on clang-sys (specifically bindgen) since there is no need to provide a path to a clang executable.