### PR TITLE
Search libclang in LIBRARY_PATH too.

### DIFF
--- a/build/common.rs
+++ b/build/common.rs
@@ -309,6 +309,14 @@ pub fn search_libclang_directories(filenames: &[String], variable: &str) -> Vec<
         }
     }
 
+    // Search the directories in the `LIBRARY_PATH` environment variable,
+    // used by GCC to find libraries to link.
+    if let Ok(path) = env::var("LIBRARY_PATH") {
+        for directory in env::split_paths(&path) {
+            found.extend(search_directories(&directory, filenames));
+        }
+    }
+
     // Determine the `libclang` directory patterns.
     let directories: Vec<&str> = if target_os!("haiku") {
         DIRECTORIES_HAIKU.into()


### PR DESCRIPTION
Systems like Guix (and maybe Nix) set the `LIBRARY_PATH` variable for compilers to find libraries when in an environment, for example:

```
guix shell --pure gcc-toolchain clang --search-paths
The following derivation will be built:
  /gnu/store/vh5jffs835hcml8pg9wlsbdnygfmfwq8-profile.drv

building CA certificate bundle...
listing Emacs sub-directories...
building fonts directory...
building directory of Info manuals...
building profile with 2 packages...
export PATH="/gnu/store/akpz799zak3qzh73m6nbql5i3mljnny5-profile/bin:/gnu/store/akpz799zak3qzh73m6nbql5i3mljnny5-profile/sbin"
export C_INCLUDE_PATH="/gnu/store/akpz799zak3qzh73m6nbql5i3mljnny5-profile/include"
export CPLUS_INCLUDE_PATH="/gnu/store/akpz799zak3qzh73m6nbql5i3mljnny5-profile/include/c++:/gnu/store/akpz799zak3qzh73m6nbql5i3mljnny5-profile/include"
export OBJC_INCLUDE_PATH="/gnu/store/akpz799zak3qzh73m6nbql5i3mljnny5-profile/include"
export LIBRARY_PATH="/gnu/store/akpz799zak3qzh73m6nbql5i3mljnny5-profile/lib"
```

This variable is used by GCC when linking libraries, e.g. when passing `-lclang` without the need to pass the path to the library in the arguments.