### PR TITLE
Directly include file from build directory instead of copying in build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -32,17 +32,9 @@ pub mod r#static;
 /// the build output directory so that it may be used when linking at runtime.
 #[cfg(feature = "runtime")]
 fn main() {
-    use std::env;
-    use std::fs::copy;
-
     if cfg!(feature = "static") {
         panic!("`runtime` and `static` features can't be combined");
     }
-
-    let out = env::var("OUT_DIR").unwrap();
-    copy("build/macros.rs", &Path::new(&out).join("macros.rs")).unwrap();
-    copy("build/common.rs", &Path::new(&out).join("common.rs")).unwrap();
-    copy("build/dynamic.rs", &Path::new(&out).join("dynamic.rs")).unwrap();
 }
 
 /// Finds and links to the required libraries dynamically or statically.

--- a/src/link.rs
+++ b/src/link.rs
@@ -190,7 +190,7 @@ https://docs.rs/clang-sys/latest/clang_sys/{0}/index.html
 
 Instructions for installing `libclang` can be found here:
 https://rust-lang.github.io/rust-bindgen/requirements.html
-"#, 
+"#,
                             stringify!($name),
                             library
                                 .version()
@@ -226,9 +226,9 @@ https://rust-lang.github.io/rust-bindgen/requirements.html
         pub fn load_manually() -> Result<SharedLibrary, String> {
             #[allow(dead_code)]
             mod build {
-                include!(concat!(env!("OUT_DIR"), "/macros.rs"));
-                pub mod common { include!(concat!(env!("OUT_DIR"), "/common.rs")); }
-                pub mod dynamic { include!(concat!(env!("OUT_DIR"), "/dynamic.rs")); }
+                include!("../build/macros.rs");
+                pub mod common { include!("../build/common.rs"); }
+                pub mod dynamic { include!("../build/dynamic.rs"); }
             }
 
             let (directory, filename) = build::dynamic::find(true)?;


### PR DESCRIPTION
We transitively depend on on `clang-sys` with the `runtime` feature and I noticed that our dependencies frequently rebuild in CI, always starting at `clang-sys`. We use the [`-Zchecksum-freshness`](https://github.com/rust-lang/cargo/issues/14136) cargo feature and this seems to interact with the build script in this crate. 

Specifically, cargo considers the build dirty because the sizes of the `build/{common,dynamic,macros}.rs` files are different after copying them to `OUT_DIR` because the `copy` implementation doesn't produce a byte for byte copy.

I took a look at how these files are used and I think it's more straightforward to `include` them directly where they are needed instead of copying them during the build and including them from `OUT_DIR`. This is what the second commit does. Alternatively, the fist commit uses `std::fs::copy` to copy the files. Both approaches fix our problem. Let me know if I overlooked something that requires doing this from build.rs, then I'll revert the other commit.