### PR TITLE
fix: get llvm static system libs

### DIFF
--- a/build/static.rs
+++ b/build/static.rs
@@ -41,7 +41,7 @@ fn get_library_name(path: &Path) -> Option<String> {
 
 /// Gets the LLVM static libraries required to link to `libclang`.
 fn get_llvm_libraries() -> Vec<String> {
-    common::run_llvm_config(&["--libs", "--link-static"])
+    common::run_llvm_config(&["--libs", "--link-static", "--system-libs"])
         .unwrap()
         .split_whitespace()
         .filter_map(|p| {


### PR DESCRIPTION
Fix missing system libs

Related: https://github.com/KyleMayes/clang-sys/pull/190