### PR TITLE
Add LIBCLANG_PATH_OVERRIDE build-time environment variable

### DIFF
--- a/build/common.rs
+++ b/build/common.rs
@@ -267,7 +267,9 @@ fn search_directories(directory: &Path, filenames: &[String]) -> Vec<(PathBuf, S
 pub fn search_libclang_directories(filenames: &[String], variable: &str) -> Vec<(PathBuf, String)> {
     // Search only the path indicated by the relevant environment variable
     // (e.g., `LIBCLANG_PATH`) if it is set.
-    if let Ok(path) = env::var(variable).map(|d| Path::new(&d).to_path_buf()) {
+    if let Some(path) = env::var(variable).map(|d| Path::new(&d).to_path_buf()).ok().or_else(|| {
+        option_env!("LIBCLANG_PATH_OVERRIDE").map(|x| x.into())
+    }) {
         // Check if the path is a matching file.
         if let Some(parent) = path.parent() {
             let filename = path.file_name().unwrap().to_str().unwrap();


### PR DESCRIPTION
Allow setting `LIBCLANG_PATH_OVERRIDE` at build time to suppress this crate's usual behavior of searching system paths rooted at / for libclang, regardless of which linking mode the crate uses.

The existing `LIBCLANG_PATH` runtime variable keeps precedence, so behavior is unchanged for everyone not setting the new variable.

This is necessary when clang-sys is built under bazel, whose sandboxed build actions must not depend on host system paths. ChromeOS has been carrying this change in its vendored copy of clang-sys for this reason.

A compile-time `option_env!` is used rather than a runtime `env::var` because build/common.rs is compiled in two contexts:
  1. Into the build script.
  2. Into the library itself, with the `runtime` feature, where the libclang search runs when the final application starts and no build system provided env exists to read.

The compile-time lookup lets the build system inject the override at whichever stage compiles this code (ChromeOS sets it for both via rules_rust's `build_script_rustc_env` and `rustc_env` annotations), keeping the result hermetic.

Based-on: https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/c375b49f53008406e84d9231b80d40a6ee824755/patches/clang-sys/add_libclang_path_override_env_var.patch