### PR TITLE
Revert "Improve clang executable search (#171)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,6 @@
 
 ## [1.8.2] - 2024-05-29
 
-### Changed
-- Improved `Clang::find` to first check directories related to the runtime-loaded `libclang` instance (if any)
-
 ### Fixed
 - Fixed linking to `libclang` on Windows with MSYS2
 - Fixed `Clang::find` to support both the `-target` and `--target` arguments

--- a/src/link.rs
+++ b/src/link.rs
@@ -100,8 +100,8 @@ macro_rules! link {
         /// A dynamically loaded instance of the `libclang` library.
         #[derive(Debug)]
         pub struct SharedLibrary {
-            pub(crate) library: libloading::Library,
-            pub(crate) path: PathBuf,
+            library: libloading::Library,
+            path: PathBuf,
             pub functions: Functions,
         }
 

--- a/src/support.rs
+++ b/src/support.rs
@@ -44,13 +44,11 @@ impl Clang {
     /// Returns a `clang` executable if one can be found.
     ///
     /// If the `CLANG_PATH` environment variable is set, that is the instance of
-    /// `clang` used. Otherwise, these directories are searched in order:
-    ///
-    ///   1. The supplied path (if provided)
-    ///   2. Sibling directories for the runtime-loaded `libclang` instance (if any)
-    ///   3. The directory returned by `llvm-config --bindir`
-    ///   4. The directory returned by `xcodebuild -find clang` (on macOS)
-    ///   5. The directories in the system's `PATH` environment variable
+    /// `clang` used. Otherwise, a series of directories are searched. First, if
+    /// a path is supplied, that is the first directory searched. Then, the
+    /// directory returned by `llvm-config --bindir` is searched. On macOS
+    /// systems, `xcodebuild -find clang` will next be queried. Last, the
+    /// directories in the system's `PATH` are searched.
     ///
     /// ## Cross-compilation
     ///
@@ -83,16 +81,6 @@ impl Clang {
 
         if let Some(path) = path {
             paths.push(path.into());
-        }
-
-        #[cfg(feature = "runtime")]
-        if let Some(library) = crate::get_library() {
-            if let Some(directory) = library.path().parent() {
-                paths.push(directory.into());
-                if let Some(parent) = directory.parent() {
-                    paths.push(parent.join("bin"));
-                }
-            }
         }
 
         if let Ok(path) = run_llvm_config(&["--bindir"]) {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -50,14 +50,3 @@ fn test_support_target() {
     let clang = support::Clang::find(None, args).unwrap();
     println!("{:?}", clang);
 }
-
-#[cfg(feature = "runtime")]
-#[test]
-fn test_support_runtime() {
-    load().unwrap();
-    let library = get_library().unwrap();
-    let clang = support::Clang::find(None, &[]).unwrap();
-    println!("Library path: {}", library.path().display());
-    println!("Clang path:   {}", clang.path.display());
-    unload().unwrap();
-}


### PR DESCRIPTION
This reverts commit e46f0bf70a5ba9885788b0e5aa139c43bf8cebfd.

This caused problems in #181, and v1.8.2 and v1.9.0 had to be yanked because of it.

Fixes https://github.com/KyleMayes/clang-sys/issues/201.
Fixes https://github.com/KyleMayes/clang-sys/issues/181.