### PR TITLE
Bump version to 1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,28 @@
-## [1.9.0] - 2024-09-24
+## [1.9.1] - 2026-06-29
+
+### Added
+- Added support for `clang` 19.0.x
+- Added support for `clang` 20.0.x
+- Added rewriter API.
+
+### Changed
+- Search for libraries in `LIBRARY_PATH` in addition to `LD_LIBRARY_PATH`.
+
+### Fixed
+- Reverted executable search that caused header search path failure on macOS.
+- Improved Visual Studio search paths.
+- Improved support for Cygwin.
+
+## [1.9.0] - 2024-09-24 [YANKED]
 
 ### Changed
 - Added `--link-static` flag when listing static libraries to link to
 
-## [1.8.2] - 2024-05-29
+## [1.8.2] - 2024-05-29 [YANKED]
 
 ### Fixed
 - Fixed linking to `libclang` on Windows with MSYS2
-- Fixed `Clang::find` to support both the `-target` and `--target` arguments
-when using target-prefixed `clang` binaries
+- Fixed `Clang::find` to support both the `-target` and `--target` arguments when using target-prefixed `clang` binaries
 
 ## [1.8.1] - 2024-05-28
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 name = "clang-sys"
 authors = ["Kyle Mayes <kyle@mayeses.com>"]
 
-version = "1.9.0"
+version = "1.9.1"
 
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Closes https://github.com/KyleMayes/clang-sys/issues/171 (already fixed in yanked versions).
Closes https://github.com/KyleMayes/clang-sys/issues/189 (already fixed in yanked versions).
Fixes https://github.com/KyleMayes/clang-sys/issues/212.