### PR TITLE
Bump MSRV to 1.71

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         clang: [["14.0", "clang_14_0"]]
-        rust: ["1.60.0"]
+        rust: ["1.71.0"]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
       # Cargo
       - name: Generate lockfile and pin dependencies for MSRV
-        run: cargo generate-lockfile && cargo update -p libc --precise 0.2.163 && cargo update -p glob --precise 0.3.2 && cargo update -p libloading --precise 0.8.8
+        run: cargo generate-lockfile && cargo update -p getrandom --precise 0.3.4
       # Test
       - name: Cargo Test (Dynamic)
         run: cargo test --verbose --features ${{ matrix.clang[1] }} -- --nocapture

--- a/.github/workflows/ssh.yml
+++ b/.github/workflows/ssh.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         clang: [["13.0", "clang_13_0"]]
-        rust: ["1.60.0"]
+        rust: ["1.71.0"]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Changed
+- Bumped minimum supported Rust version (MSRV) to 1.71.0
+
 ## [1.9.1] - 2026-06-29
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ repository = "https://github.com/KyleMayes/clang-sys"
 links = "clang"
 build = "build.rs"
 
+rust-version = "1.71"
+
 [features]
 
 clang_3_5 = []
@@ -62,7 +64,7 @@ glob = "0.3"
 
 glob = "0.3"
 lazy_static = "1"
-tempfile = ">=3.0.0, <3.7.0"
+tempfile = "3.6.0"
 
 [package.metadata.docs.rs]
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Crate](https://img.shields.io/crates/v/clang-sys.svg)](https://crates.io/crates/clang-sys)
 [![Documentation](https://docs.rs/clang-sys/badge.svg)](https://docs.rs/clang-sys)
 [![CI](https://img.shields.io/github/actions/workflow/status/KyleMayes/clang-sys/ci.yml?branch=master)](https://github.com/KyleMayes/clang-sys/actions?query=workflow%3ACI)
-![MSRV](https://img.shields.io/badge/MSRV-1.60.0-blue)
+![MSRV](https://img.shields.io/badge/MSRV-1.71.0-blue)
 
 Rust bindings for `libclang`.
 


### PR DESCRIPTION
Allows (possibly) using extern "C-unwind" in the future, see #202, and makes CI much faster due to not needing to download the whole Cargo git index.

We could probably go higher, but let's wait with that until there is a pressing need. Bindgen will also bump MSRV to 1.71 in https://github.com/rust-lang/rust-bindgen/pull/3401.